### PR TITLE
Protocol switch #3

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1114,8 +1114,8 @@ static const int64 nInterval = nTargetTimespan / nTargetSpacing;
 
 static const int64 fNewDifficultyProtocol3 = 88000;
 
-static const int64 nMaxAdjustDown = 20; // 20% adjustment down
-static const int64 nMaxAdjustUp = 5; // 5% adjustment up
+static const int64 nMaxAdjustDown = 5; // 5% max adjustment down
+static const int64 nMaxAdjustUp = 5; // 5% max adjustment up
 
 static const int64 nTargetTimespanAdjDown = (100 + nMaxAdjustDown) / 100;
 

--- a/src/main.h
+++ b/src/main.h
@@ -168,6 +168,8 @@ bool CheckWork(CBlock* pblock, CWallet& wallet, CReserveKey& reservekey);
 bool CheckProofOfWork(uint256 hash, unsigned int nBits);
 /** Calculate the minimum amount of work a received block needs, without knowing its direct parent */
 unsigned int ComputeMinWork(unsigned int nBase, int64 nTime);
+/** Calculate the minimum amount of work a received block needs, without knowing its direct parent  (ProtocolSwitch3) */
+unsigned int NeoComputeMinWork(unsigned int nBase, int64 nTime); // TODO: Unit test.
 /** Get the number of active peers */
 int GetNumBlocksOfPeers();
 /** Check whether we are doing an initial block download (synchronizing from disk or network) */

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1906,7 +1906,7 @@ bool BindListenPort(const CService &addrBind, string& strError)
     {
         int nErr = WSAGetLastError();
         if (nErr == WSAEADDRINUSE)
-            strError = strprintf(_("Unable to bind to %s on this computer. Litecoin is probably already running."), addrBind.ToString().c_str());
+            strError = strprintf(_("Unable to bind to %s on this computer. Anoncoin is probably already running."), addrBind.ToString().c_str());
         else
             strError = strprintf(_("Unable to bind to %s on this computer (bind returned error %d, %s)"), addrBind.ToString().c_str(), nErr, strerror(nErr));
         printf("%s\n", strError.c_str());


### PR DESCRIPTION
To fix our current issues, this is the suggestion:

Retarget each block.
- Look back 1 block. E.g when mining block 87284, it check the time diff between block 87282 and 87283.
- 5% MAX adjustment down 
- 5% MAX adjustment up
