### PR TITLE
Rename "Anoncoin-Qt" to "Anoncoin". New README.md file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,7 +95,7 @@ src/qt/test/moc*.cpp
 # Compilation and Qt preprocessor part
 *.qm
 anoncoin-qt
-Anoncoin-Qt.app
+Anoncoin.app
 
 # Unit-tests
 Makefile.test

--- a/Makefile.am
+++ b/Makefile.am
@@ -18,8 +18,8 @@ ANONCOIN_QT_BIN=$(top_builddir)/src/qt/anoncoin-qt$(EXEEXT)
 ANONCOIN_CLI_BIN=$(top_builddir)/src/anoncoin-cli$(EXEEXT)
 ANONCOIN_WIN_INSTALLER=$(PACKAGE)-$(PACKAGE_VERSION)-win$(WINDOWS_BITS)-setup$(EXEEXT)
 
-OSX_APP=Anoncoin-Qt.app
-OSX_DMG=Anoncoin-Qt.dmg
+OSX_APP=Anoncoin.app
+OSX_DMG=Anoncoin.dmg
 OSX_DEPLOY_SCRIPT=$(top_srcdir)/contrib/macdeploy/macdeployqtplus
 OSX_FANCY_PLIST=$(top_srcdir)/contrib/macdeploy/fancy.plist
 OSX_INSTALLER_ICONS=$(top_srcdir)/src/qt/res/icons/anoncoin.icns
@@ -84,13 +84,13 @@ $(OSX_APP)/Contents/Resources/anoncoin.icns: $(OSX_INSTALLER_ICONS)
 	$(MKDIR_P) $(@D)
 	$(INSTALL_DATA) $< $@
 
-$(OSX_APP)/Contents/MacOS/Anoncoin-Qt: $(ANONCOIN_QT_BIN)
+$(OSX_APP)/Contents/MacOS/Anoncoin: $(ANONCOIN_QT_BIN)
 	$(MKDIR_P) $(@D)
 	STRIPPROG="$(STRIP)" $(INSTALL_STRIP_PROGRAM)  $< $@
 
 OSX_APP_BUILT=$(OSX_APP)/Contents/PkgInfo $(OSX_APP)/Contents/Resources/empty.lproj \
   $(OSX_APP)/Contents/Resources/anoncoin.icns $(OSX_APP)/Contents/Info.plist \
-  $(OSX_APP)/Contents/MacOS/Anoncoin-Qt
+  $(OSX_APP)/Contents/MacOS/Anoncoin
 
 if BUILD_DARWIN
 $(OSX_DMG): $(OSX_APP_BUILT) $(OSX_PACKAGING)
@@ -105,10 +105,10 @@ $(APP_DIST_DIR)/Applications:
 	@rm -f $@
 	@cd $(@D); $(LN_S) /Applications $(@F)
 
-$(APP_DIST_EXTRAS): $(APP_DIST_DIR)/$(OSX_APP)/Contents/MacOS/Anoncoin-Qt
+$(APP_DIST_EXTRAS): $(APP_DIST_DIR)/$(OSX_APP)/Contents/MacOS/Anoncoin
 
 $(OSX_DMG): $(APP_DIST_EXTRAS)
-	$(GENISOIMAGE) -no-cache-inodes -D -l -probe -V "Anoncoin-Qt" -no-pad -r -apple -o $@ dist
+	$(GENISOIMAGE) -no-cache-inodes -D -l -probe -V "Anoncoin" -no-pad -r -apple -o $@ dist
 
 $(APP_DIST_DIR)/.background/background.png:
 	$(MKDIR_P) $(@D)
@@ -116,7 +116,7 @@ $(APP_DIST_DIR)/.background/background.png:
 $(APP_DIST_DIR)/.DS_Store:
 	$(INSTALL) $(top_srcdir)/contrib/macdeploy/DS_Store $@
 
-$(APP_DIST_DIR)/$(OSX_APP)/Contents/MacOS/Anoncoin-Qt: $(OSX_APP_BUILT) $(OSX_PACKAGING)
+$(APP_DIST_DIR)/$(OSX_APP)/Contents/MacOS/Anoncoin: $(OSX_APP_BUILT) $(OSX_PACKAGING)
 	INSTALLNAMETOOL=$(INSTALLNAMETOOL)  OTOOL=$(OTOOL) STRIP=$(STRIP) $(OSX_DEPLOY_SCRIPT) $(OSX_APP) -translations-dir=$(QT_TRANSLATION_DIR) -add-qt-tr $(OSX_QT_TRANSLATIONS) -verbose 2
 
 deploydir: $(APP_DIST_EXTRAS)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,5 @@ worked on by several people. The develop branch should be used with extreme caut
 Anoncoin website: [anoncoin.net](https://anoncoin.net/)<br />
 Anoncoin wiki: [wiki.anoncoin.net](https://wiki.anoncoin.net/)<br />
 email: [contact@anoncoin.net](mailto:contact@anoncoin.net)<br />
-IRC: #anoncoin (I2P: localhost port 6668 / Freenode: irc.freenode.net port 6667)
+IRC: #anoncoin (I2P: localhost port 6668 / Freenode: irc.freenode.net port 6667)<br />
 Twitter: [AnoncoinNews](https://twitter.com/AnoncoinNews), [AnoncoinProject](https://twitter.com/AnoncoinProject)
-Reddit: [www.reddit.com/r/Anoncoin/](http://www.reddit.com/r/Anoncoin/)

--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
 The Anoncoin project
 ====================
 
-Build Statuses
----------------
-- Linux build - [![Build Status - Linux](https://jenkins.nordcloud.no/buildStatus/icon?job=Anoncoin-Linux)](https://jenkins.nordcloud.no/job/Anoncoin-Linux/)
-- Mingw-w64 (Windows) - [![Build Status - Mingw-w64](https://jenkins.nordcloud.no/buildStatus/icon?job=Anoncoin-Mingw-w64)](https://jenkins.nordcloud.no/job/Anoncoin-Mingw-w64/)
-- OSX (Too be added real soon)
+Anoncoin (ANC) is a peer-to-peer digital cryptocurrency that focuses on privacy and anonymity for its users. Created in June 2013, it is the first and only currency to have built-in support for both the I2P darknet and Tor network that conceal the IP address of the user. Anoncoin will soon be implementing Zerocoin, which will allow users to make payments anonymously, without revealing their anoncoin public addresses.
 
+###About the Coin###
+* Launch date: June 6, 2013
+* Proof of work algorithm: Scrypt
+* Block generation: 3 minute block targets
+* Block reward: 4.2 ANC for blocks until 42,000; 7 ANC until block 77,777; a 10 ANC bonus block for 77778; 5 ANC until block 306,600; and then halving of block rewards every 306,600 blocks (approximately every 638 days).
+* Maximum number of coins: 3.1 million ANC
+* Anonymity: Native support of the I2P and Tor darknets, Zerocoin in development
+* Premine: 4200 ANC returned to the community
 
-Specs:
-
-Anoncoin - a fork version of Litecoin optimized for CPU mining using scrypt as a proof of work scheme.
- - 3.42 minute block targets (retarget on ~1680 blocks, 4days)
- - Starts with 4.2 coin blocks until block 42000
- - 7 coin blocks until block 77777
- - 5 coin blocks after 77778, then subsidy halves in 306600 blocks (~2 years)
+###For more info###
+[Anoncoin website](https://anoncoin.net/)
+[Anoncoin wiki](https://wiki.anoncoin.net/)
+[email](mailto:contact@anoncoin.net)
+IRC channel: #anoncoin
 
 Development process
 ===================
@@ -22,17 +24,12 @@ Development process
 Developers work in their own trees, then submit pull requests when
 they think their feature or bug fix is ready.
 
-The patch will be accepted if there is broad consensus that it is a
-good thing.  Developers should expect to rework and resubmit patches
-if they don't match the project's coding conventions (see coding.txt)
-or are controversial.
-
 The master branch is regularly built and tested, but is not guaranteed
 to be completely stable. Tags are regularly created to indicate new
-official, stable release versions of Anoncoin.
+official, stable release versions of Anoncoin. 
 
 Feature branches are created when there are major new features being
-worked on by several people.
+worked on by several people. The develop branch should be used with extreme caution.
 
 From time to time a pull request will become outdated. If this occurs, and
 the pull is no longer automatically mergeable; a comment on the pull will

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Developers work in their own trees, then submit pull requests when
 they think their feature or bug fix is ready. The master branch is regularly built and tested, but is not guaranteed to be completely stable. Tags are regularly created to indicate new official, stable release versions of Anoncoin. Feature branches are created when there are major new features being
 worked on by several people. The develop branch should be used with extreme caution.
 
-##For more info##
+##For more information##
 Anoncoin website: [anoncoin.net](https://anoncoin.net/)<br />
 Anoncoin wiki: [wiki.anoncoin.net](https://wiki.anoncoin.net/)<br />
 email: [contact@anoncoin.net](mailto:contact@anoncoin.net)<br />

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ they think their feature or bug fix is ready. The master branch is regularly bui
 worked on by several people. The develop branch should be used with extreme caution.
 
 ##For more information##
-Anoncoin website: [anoncoin.net](https://anoncoin.net/)<br />
-Anoncoin wiki: [wiki.anoncoin.net](https://wiki.anoncoin.net/)<br />
-email: [contact@anoncoin.net](mailto:contact@anoncoin.net)<br />
-IRC: #anoncoin (I2P: localhost port 6668 / Freenode: irc.freenode.net port 6667)<br />
-Twitter: [AnoncoinNews](https://twitter.com/AnoncoinNews), [AnoncoinProject](https://twitter.com/AnoncoinProject)
+**Anoncoin website:** [anoncoin.net](https://anoncoin.net/)<br />
+**Anoncoin wiki:** [wiki.anoncoin.net](https://wiki.anoncoin.net/)<br />
+**email:** [contact@anoncoin.net](mailto:contact@anoncoin.net)<br />
+**IRC:** #anoncoin (I2P: localhost port 6668 / Freenode: irc.freenode.net port 6667)<br />
+**Twitter:** [AnoncoinNews](https://twitter.com/AnoncoinNews), [AnoncoinProject](https://twitter.com/AnoncoinProject)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Feature branches are created when there are major new features being
 worked on by several people. The develop branch should be used with extreme caution.
 
 ##For more info##
-[Anoncoin website](https://anoncoin.net/)<br />
-[Anoncoin wiki](https://wiki.anoncoin.net/)<br />
-[email](mailto:contact@anoncoin.net)<br />
-IRC channel: #anoncoin
+Anoncoin website [anoncoin.net](https://anoncoin.net/)<br />
+Anoncoin wiki [wiki.anoncoin.net](https://wiki.anoncoin.net/)<br />
+email [contact@anoncoin.net](mailto:contact@anoncoin.net)<br />
+IRC channel: #anoncoin (I2P: localhost port 6668 / Freenode: irc.freenode.net port 6667)

--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ Anoncoin website: [anoncoin.net](https://anoncoin.net/)<br />
 Anoncoin wiki: [wiki.anoncoin.net](https://wiki.anoncoin.net/)<br />
 email: [contact@anoncoin.net](mailto:contact@anoncoin.net)<br />
 IRC: #anoncoin (I2P: localhost port 6668 / Freenode: irc.freenode.net port 6667)
+Twitter: [AnoncoinNews](https://twitter.com/AnoncoinNews), [AnoncoinProject](https://twitter.com/AnoncoinProject)
+Reddit: [www.reddit.com/r/Anoncoin/](http://www.reddit.com/r/Anoncoin/)

--- a/README.md
+++ b/README.md
@@ -15,15 +15,11 @@ Anoncoin (ANC) is a peer-to-peer digital cryptocurrency that focuses on privacy 
 ##Development process##
 
 Developers work in their own trees, then submit pull requests when
-they think their feature or bug fix is ready. The master branch is regularly built and tested, but is not guaranteed
-to be completely stable. Tags are regularly created to indicate new
-official, stable release versions of Anoncoin. 
-
-Feature branches are created when there are major new features being
+they think their feature or bug fix is ready. The master branch is regularly built and tested, but is not guaranteed to be completely stable. Tags are regularly created to indicate new official, stable release versions of Anoncoin. Feature branches are created when there are major new features being
 worked on by several people. The develop branch should be used with extreme caution.
 
 ##For more info##
-Anoncoin website [anoncoin.net](https://anoncoin.net/)<br />
-Anoncoin wiki [wiki.anoncoin.net](https://wiki.anoncoin.net/)<br />
-email [contact@anoncoin.net](mailto:contact@anoncoin.net)<br />
-IRC channel: #anoncoin (I2P: localhost port 6668 / Freenode: irc.freenode.net port 6667)
+Anoncoin website: [anoncoin.net](https://anoncoin.net/)<br />
+Anoncoin wiki: [wiki.anoncoin.net](https://wiki.anoncoin.net/)<br />
+email: [contact@anoncoin.net](mailto:contact@anoncoin.net)<br />
+IRC: #anoncoin (I2P: localhost port 6668 / Freenode: irc.freenode.net port 6667)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ The Anoncoin project
 
 Anoncoin (ANC) is a peer-to-peer digital cryptocurrency that focuses on privacy and anonymity for its users. Created in June 2013, it is the first and only currency to have built-in support for both the I2P darknet and Tor network that conceal the IP address of the user. Anoncoin will soon be implementing Zerocoin, which will allow users to make payments anonymously, without revealing their anoncoin public addresses.
 
-###About the Coin###
+##About the Coin##
 * Launch date: June 6, 2013
 * Proof of work algorithm: Scrypt
 * Block generation: 3 minute block targets
@@ -12,32 +12,18 @@ Anoncoin (ANC) is a peer-to-peer digital cryptocurrency that focuses on privacy 
 * Anonymity: Native support of the I2P and Tor darknets, Zerocoin in development
 * Premine: 4200 ANC returned to the community
 
-###For more info###
-[Anoncoin website](https://anoncoin.net/)
-[Anoncoin wiki](https://wiki.anoncoin.net/)
-[email](mailto:contact@anoncoin.net)
-IRC channel: #anoncoin
-
-Development process
-===================
+##Development process##
 
 Developers work in their own trees, then submit pull requests when
-they think their feature or bug fix is ready.
-
-The master branch is regularly built and tested, but is not guaranteed
+they think their feature or bug fix is ready. The master branch is regularly built and tested, but is not guaranteed
 to be completely stable. Tags are regularly created to indicate new
 official, stable release versions of Anoncoin. 
 
 Feature branches are created when there are major new features being
 worked on by several people. The develop branch should be used with extreme caution.
 
-From time to time a pull request will become outdated. If this occurs, and
-the pull is no longer automatically mergeable; a comment on the pull will
-be used to issue a warning of closure. The pull will be closed 15 days
-after the warning if action is not taken by the author. Pull requests closed
-in this manner will have their corresponding issue labeled 'stagnant'.
-
-Issues with no commits will be given a similar warning, and closed after
-15 days from their last activity. Issues closed in this manner will be 
-labeled 'stale'. 
-
+##For more info##
+[Anoncoin website](https://anoncoin.net/)<br />
+[Anoncoin wiki](https://wiki.anoncoin.net/)<br />
+[email](mailto:contact@anoncoin.net)<br />
+IRC channel: #anoncoin

--- a/contrib/macdeploy/README.md
+++ b/contrib/macdeploy/README.md
@@ -11,5 +11,5 @@ This script should not be run manually, instead, after building as usual:
 During the process, the disk image window will pop up briefly where the fancy
 settings are applied. This is normal, please do not interfere.
 
-When finished, it will produce `Anoncoin-Qt.dmg`.
+When finished, it will produce `Anoncoin.dmg`.
 

--- a/contrib/macdeploy/detached-sig-apply.sh
+++ b/contrib/macdeploy/detached-sig-apply.sh
@@ -5,7 +5,7 @@ UNSIGNED=$1
 SIGNATURE=$2
 ARCH=x86_64
 ROOTDIR=dist
-BUNDLE=${ROOTDIR}/Anoncoin-Qt.app
+BUNDLE=${ROOTDIR}/Anoncoin.app
 TEMPDIR=signed.temp
 OUTDIR=signed-app
 

--- a/contrib/macdeploy/detached-sig-create.sh
+++ b/contrib/macdeploy/detached-sig-create.sh
@@ -2,7 +2,7 @@
 set -e
 
 ROOTDIR=dist
-BUNDLE=${ROOTDIR}/Anoncoin-Qt.app
+BUNDLE=${ROOTDIR}/Anoncoin.app
 CODESIGN=codesign
 TEMPDIR=sign.temp
 TEMPLIST=${TEMPDIR}/signatures.txt

--- a/contrib/macdeploy/fancy.plist
+++ b/contrib/macdeploy/fancy.plist
@@ -22,7 +22,7 @@
 			<integer>370</integer>
 			<integer>156</integer>
 		</array>
-		<key>Anoncoin-Qt.app</key>
+		<key>Anoncoin.app</key>
 		<array>
 			<integer>128</integer>
 			<integer>156</integer>

--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -836,7 +836,7 @@ if config.dmg is not None:
                 items_positions.append(itemscript.substitute(params))
 
         params = {
-            "disk" : "Anoncoin-Qt",
+            "disk" : "Anoncoin",
             "window_bounds" : "300,300,800,620",
             "icon_size" : "96",
             "background_commands" : "",

--- a/share/qt/Info.plist.in
+++ b/share/qt/Info.plist.in
@@ -29,10 +29,10 @@
   <string>????</string>
 
   <key>CFBundleExecutable</key>
-  <string>Anoncoin-Qt</string>
+  <string>Anoncoin</string>
 
   <key>CFBundleIdentifier</key>
-  <string>org.anoncoindotnet.Anoncoin-Qt</string>
+  <string>org.anoncoindotnet.Anoncoin</string>
 
   <key>CFBundleURLTypes</key>
   <array>

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -50,7 +50,7 @@ static const int MAX_PAYMENT_REQUEST_SIZE = 50000; // bytes
 
 #define QAPP_ORG_NAME "Anoncoin"
 #define QAPP_ORG_DOMAIN "anoncoin.net"
-#define QAPP_APP_NAME_DEFAULT "Anoncoin-Qt"
-#define QAPP_APP_NAME_TESTNET "Anoncoin-Qt-testnet"
+#define QAPP_APP_NAME_DEFAULT "Anoncoin"
+#define QAPP_APP_NAME_TESTNET "Anoncoin-testnet"
 
 #endif // GUICONSTANTS_H

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
     // Don't remove this, it's needed to access
     // QCoreApplication:: in the tests
     QCoreApplication app(argc, argv);
-    app.setApplicationName("Anoncoin-Qt-test");
+    app.setApplicationName("Anoncoin-test");
 
     URITests test1;
     if (QTest::qExec(&test1) != 0)


### PR DESCRIPTION
This pull request changes the name of the Anoncoin-Qt application to Anoncoin (this does not affect the naming of the "anoncoin-qt" binaries. Secondly, I include a new README.md file.
