### PR TITLE
Early march 2015 updates for client version v0.9.4.5 builds...

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -88,6 +88,7 @@ ANONCOIN_CORE_H = \
   bignum.h \
   bloom.h \
   chainparams.h \
+  chainparamsbase.h \
   checkpoints.h \
   checkqueue.h \
   clientversion.h \
@@ -233,6 +234,7 @@ libanoncoin_util_a_CPPFLAGS = $(ANONCOIN_INCLUDES)
 libanoncoin_util_a_SOURCES = \
   compat/glibc_sanity.cpp \
   compat/glibcxx_sanity.cpp \
+  chainparamsbase.cpp \
   clientversion.cpp \
   rpcprotocol.cpp \
   sync.cpp \
@@ -279,7 +281,6 @@ anoncoind_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 # anoncoin-cli binary #
 anoncoin_cli_LDADD = \
   $(LIBANONCOIN_CLI) \
-  $(LIBANONCOIN_COMMON) \
   $(LIBANONCOIN_UTIL) \
   $(BOOST_LIBS) \
   $(SSL_LIBS) \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -48,7 +48,6 @@ ANONCOIN_TESTS =\
   test/hmac_tests.cpp \
   test/key_tests.cpp \
   test/main_tests.cpp \
-  test/miner_tests.cpp \
   test/mruset_tests.cpp \
   test/multisig_tests.cpp \
   test/netbase_tests.cpp \

--- a/src/alert.h
+++ b/src/alert.h
@@ -3,9 +3,8 @@
 // Copyright (c) 2013-2014 The Anoncoin Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
 #ifndef _ANONCOINALERT_H_
-#define _ANONCOINALERT_H_ 1
+#define _ANONCOINALERT_H_
 
 #include "serialize.h"
 #include "sync.h"
@@ -106,5 +105,4 @@ public:
      */
     static CAlert getAlertByHash(const uint256 &hash);
 };
-
-#endif
+#endif // header guard

--- a/src/anoncoin-cli.cpp
+++ b/src/anoncoin-cli.cpp
@@ -4,18 +4,13 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-// Many builder specific things set in the config file, don't forget to include it this way in your source files.
-#ifdef HAVE_CONFIG_H
-#include "config/anoncoin-config.h"
-#endif
-
+#include "clientversion.h"          // Including this file always also includes config/anoncoin-config.h which defines many specific build time parameters
+#include "chainparamsbase.h"
 #include "util.h"
 #include "init.h"
 #include "rpcclient.h"
 #include "rpcprotocol.h"
 #include "ui_interface.h" /* for _(...) */
-#include "chainparams.h"
-#include "clientversion.h"
 
 #include <boost/filesystem/operations.hpp>
 
@@ -41,7 +36,7 @@ static bool AppInitRPC(int argc, char* argv[])
         return false;
     }
     // Check for -testnet or -regtest parameter (TestNet() calls are only valid after this clause)
-    if (!SelectParamsFromCommandLine()) {
+    if (!SelectBaseParamsFromCommandLine()) {
         fprintf(stderr, "Error: Invalid combination of -regtest and -testnet.\n");
         return false;
     }

--- a/src/anoncoind.cpp
+++ b/src/anoncoind.cpp
@@ -21,14 +21,14 @@
  *
  * \section intro_sec Introduction
  *
- * Anoncoin (ANC) is a peer-to-peer digital cryptocurrency that focuses on privacy and anonymity 
- * for its users. Created in June 2013, it is the first and only currency to have built-in support 
- * for both the I2P darknet and Tor network that conceal the IP address of the user. Anoncoin 
- * will soon be implementing Zerocoin, which will allow users to make payments anonymously, 
+ * Anoncoin (ANC) is a peer-to-peer digital cryptocurrency that focuses on privacy and anonymity
+ * for its users. Created in June 2013, it is the first and only currency to have built-in support
+ * for both the I2P darknet and Tor network that conceal the IP address of the user. Anoncoin
+ * will soon be implementing Zerocoin, which will allow users to make payments anonymously,
  * without revealing their anoncoin public addresses.
  *
  * This site contains the developer documentation of the Anoncoin code. Further information
- * can be found on the Anoncoin web site (https://anoncoin.net/) and wiki 
+ * can be found on the Anoncoin web site (https://anoncoin.net/) and wiki
  * (https://wiki.anoncoin.net/).
  *
  * The software is a community-driven open source project, released under the MIT license.
@@ -65,13 +65,34 @@ bool AppInit(int argc, char* argv[])
     boost::thread* detectShutdownThread = NULL;
 
     bool fRet = false;
+
+    //
+    // Parameters
+    //
+    // If Qt is used, parameters/anoncoin.conf are parsed in qt/anoncoin.cpp's main()
+    ParseParameters(argc, argv);
+
+    // Process help and (ToDo: version) before taking care about datadir
+    if (mapArgs.count("-?") || mapArgs.count("--help"))
+    {
+        // First part of help message is specific to anoncoind / RPC client
+        std::string strUsage = _("Anoncoin Core Daemon") + " " + _("version") + " " + FormatFullVersion() + "\n\n" +
+            _("Usage:") + "\n" +
+              "  anoncoind [options]                     " + _("Start Anoncoin Core Daemon") + "\n" +
+            _("Usage (deprecated, use anoncoin-cli):") + "\n" +
+              "  anoncoind [options] <command> [params]  " + _("Send command to Anoncoin Core") + "\n" +
+              "  anoncoind [options] help                " + _("List commands") + "\n" +
+              "  anoncoind [options] help <command>      " + _("Get help for a command") + "\n";
+
+        strUsage += "\n" + HelpMessage(HMM_ANONCOIND);
+        strUsage += "\n" + HelpMessageCli(false);
+
+        fprintf(stdout, "%s", strUsage.c_str());
+        return false;
+    }
+
     try
     {
-        //
-        // Parameters
-        //
-        // If Qt is used, parameters/anoncoin.conf are parsed in qt/anoncoin.cpp's main()
-        ParseParameters(argc, argv);
         if (!boost::filesystem::is_directory(GetDataDir(false)))
         {
             fprintf(stderr, "Error: Specified data directory \"%s\" does not exist.\n", mapArgs["-datadir"].c_str());
@@ -87,24 +108,6 @@ bool AppInit(int argc, char* argv[])
         // Check for -testnet or -regtest parameter (TestNet() calls are only valid after this clause)
         if (!SelectParamsFromCommandLine()) {
             fprintf(stderr, "Error: Invalid combination of -regtest and -testnet.\n");
-            return false;
-        }
-
-        if (mapArgs.count("-?") || mapArgs.count("--help"))
-        {
-            // First part of help message is specific to anoncoind / RPC client
-            std::string strUsage = _("Anoncoin Core Daemon") + " " + _("version") + " " + FormatFullVersion() + "\n\n" +
-                _("Usage:") + "\n" +
-                  "  anoncoind [options]                     " + _("Start Anoncoin Core Daemon") + "\n" +
-                _("Usage (deprecated, use anoncoin-cli):") + "\n" +
-                  "  anoncoind [options] <command> [params]  " + _("Send command to Anoncoin Core") + "\n" +
-                  "  anoncoind [options] help                " + _("List commands") + "\n" +
-                  "  anoncoind [options] help <command>      " + _("Get help for a command") + "\n";
-
-            strUsage += "\n" + HelpMessage(HMM_ANONCOIND);
-            strUsage += "\n" + HelpMessageCli(false);
-
-            fprintf(stdout, "%s", strUsage.c_str());
             return false;
         }
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -43,14 +43,27 @@ public:
         pchMessageStart[1] = 0xca;
         pchMessageStart[2] = 0xba;
         pchMessageStart[3] = 0xda;
-        vAlertPubKey = ParseHex("04b2941a448ab9860beb73fa2f600c09bf9fe4d18d5ff0b3957bf94c6d177d61f88660d7c0dd9adef984080ddea03c898039759f66c2011c111c4394692f814962");
+
+        /** \brief
+         * Starting with Anoncoin v0.9.4.5, the following vAlertPubKey ECDSA (Elliptical Curve DSA) value will be used as the public key
+         * for generating new alerts on the Anoncoin Network. The private key is not available, nor is it in the hands of
+         * just one individual. This change will however allow the current development team to generate Alert messages as required.
+         * As of 3/3/2015  Holders of the new private key are: K1773R, Lunokhod, Cryptoslave and myself GroundRod.
+         * If an alert is necessary, it can be used to quickly inform all the nodes of an important development or software upgrade.
+         *
+         */
+        vAlertPubKey = ParseHex("04c6db35c11724e526f6725cc5bd5293b4bc9382397856e1bcef7111fb44ce357fd12442b34c496d937a348c1dca1e36ae0c0e128905eb3d301433887e8f0b4536");
+
+        // Effective 3/3/2015, the following Alert key is no longer being used & has been replaced.
+        // One last build of the v8 client is being prepared to support the new Alert key above, that is version 0.8.5.7.
+        vOldAlertPubKey = ParseHex("04b2941a448ab9860beb73fa2f600c09bf9fe4d18d5ff0b3957bf94c6d177d61f88660d7c0dd9adef984080ddea03c898039759f66c2011c111c4394692f814962");
+
         nDefaultPort = 9377;
         nRPCPort = 9376;
 
-        // As of Feb '15, SCRYPT is all that matters, future merge-mining with Bitcoin & Primecoin will what to have those limits set here.
+        // As of March '15, SCRYPT is all that matters, future mining with a SHA256D algo may soon be supported as well, set those limits here.
         bnProofOfWorkLimit[ALGO_SCRYPT] = CBigNum().SetCompact(0x1e0ffff0);  // As defined in Anoncoin 8.6....
-        bnProofOfWorkLimit[ALGO_SHA256D] = CBigNum(~uint256(0) >> 32);           // ToDo: Bitcoin difficulty is very high (taken from 9.99 code 12/2014)
-        bnProofOfWorkLimit[ALGO_PRIME] = CBigNum(~uint256(0) >> 20);             // ToDo: PRIME Proof of work limit needs research, typically same as Primecoin.
+        bnProofOfWorkLimit[ALGO_SHA256D] = CBigNum(~uint256(0) >> 32);       // ToDo: Bitcoin difficulty is very high (taken from 9.99 code 12/2014)
 
         // Anoncoin Genesis block details:
         //2ca51355580bb293fe369c5f34954069c263e9a9e8d70945ebb4c38f05778558
@@ -111,10 +124,16 @@ public:
         i2pvSeeds.push_back(CDNSSeedData("xynjl64xlviqhkjl2fbvupj7y3wct46jtayoxm2ksba6tqzo6tsa.b32.i2p", "xynjl64xlviqhkjl2fbvupj7y3wct46jtayoxm2ksba6tqzo6tsa.b32.i2p")); // Cryptoslave's seednode
 #endif // ENABLE_I2PSAM
 
-        base58Prefixes[PUBKEY_ADDRESS] = list_of(23);           // Anoncoin addresses start with A
-        base58Prefixes[SCRIPT_ADDRESS] = list_of(5);
+        // Because the prefix bytes are attached to a base256 encoding (ie, binary) of known width,  they affect the leading cinquantoctal digit of the corresponding base58
+        // representation of the same number.  The 23 below, is why mainnet pay-to-pubkey txouts always start with the letter A
+        base58Prefixes[PUBKEY_ADDRESS] = list_of(23);           // the pay-to-pubkey prefix byte
+        base58Prefixes[SCRIPT_ADDRESS] = list_of(5);            // the pay-to-script-hash prefix byte
         base58Prefixes[SECRET_KEY] =     list_of(151);          // Anoncoin secret keys are the Public Key + 128
-        // ToDo: The following two values need to be checked, and confirmed as correct, for what we want Anoncoin values to be
+        // What we have here are the same as Bitcoin values, and explained below as follows:
+        // The four-byte prefixes correspond to cinquantoctal prefixes 'xpub' and 'xprv' on mainnet and 'tpub' and 'tprv' on testnet.
+        // Somebody with far too much time to invest in encoding transformations figured out what range of numeric values would start
+        // with 'xpub' and 'xpriv' etc when converted to base58 from a binary number 4 bytes wider than a key value, then exactly which
+        // four bytes to prefix to ensure that the base256 representation always yields a number in that range.
         base58Prefixes[EXT_PUBLIC_KEY] = list_of(0x04)(0x88)(0xB2)(0x1E);
         base58Prefixes[EXT_SECRET_KEY] = list_of(0x04)(0x88)(0xAD)(0xE4);
 
@@ -184,10 +203,9 @@ public:
         nDefaultPort = 19377;
         nRPCPort = 19376;
 
-        // ToDo: Proof of work limits for testnet.  Adjust as needed, not sure what the v0.8.5.6 client has for a value, SCRYPT is all that matters at this time.
-        bnProofOfWorkLimit[ALGO_SCRYPT] = CBigNum(~uint256(0) >> 10);
-        bnProofOfWorkLimit[ALGO_SHA256D] = CBigNum(~uint256(0) >> 10);
-        bnProofOfWorkLimit[ALGO_PRIME] = CBigNum(~uint256(0) >> 10);
+        // ToDo: Proof of work limits for testnet.  Adjust as needed...
+        bnProofOfWorkLimit[ALGO_SCRYPT] = CBigNum(~uint256(0) >> 17);
+        bnProofOfWorkLimit[ALGO_SHA256D] = CBigNum(~uint256(0) >> 20);
 
         // Modify the testnet genesis block so the timestamp is valid for a later start.
         // These values have been set to the same as the v0.8.5.6 client had, so testing should be possible with that client, although maynot be required.
@@ -210,7 +228,7 @@ public:
 
         base58Prefixes[PUBKEY_ADDRESS] = list_of(111);      // Anoncoin v8 compatible testnet Public keys use this value
         base58Prefixes[SCRIPT_ADDRESS] = list_of(196);
-        base58Prefixes[SECRET_KEY]     = list_of(239);      // Anoncoin testnet secret keys are the Public Key + 128
+        base58Prefixes[SECRET_KEY]     = list_of(239);      // Anoncoin testnet secret keys start with the same prefix as the Public Key + 128
         base58Prefixes[EXT_PUBLIC_KEY] = list_of(0x04)(0x35)(0x87)(0xCF);
         base58Prefixes[EXT_SECRET_KEY] = list_of(0x04)(0x35)(0x83)(0x94);
     }
@@ -239,7 +257,6 @@ public:
         // ToDo: Proof of work limits, for regression testing are very small, more than likely these should work
         bnProofOfWorkLimit[ALGO_SCRYPT] = CBigNum(~uint256(0) >> 1);
         bnProofOfWorkLimit[ALGO_SHA256D] = CBigNum(~uint256(0) >> 1);
-        bnProofOfWorkLimit[ALGO_PRIME] = CBigNum(~uint256(0) >> 1);
 
         genesis.nTime = 1296688602;
         genesis.nBits = 0x207fffff;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -153,12 +153,15 @@ public:
             vFixedSeeds.push_back(addr);
         }
 #ifdef ENABLE_I2PSAM
-        // As of 12/26/2014, there are NO entries from above clearnet pnSeed array, only using I2P for fixed seeding, and the values are assumed to be
-        // full I2P destination addresses.
+        // As of 12/26/2014, there are NO entries for the above clearnet pnSeed array,
+        // only using I2P for fixed seeding now, the strings are base64 encoded I2P
+        // Destination addresses, and we set the port to 0.
         for (unsigned int i = 0; i < ARRAYLEN( I2pSeedAddresses ); i++ ) {
             const int64_t nOneWeek = 7*24*60*60;
-            CService aServiceSeed( I2pSeedAddresses[i] );
-            CAddress addr( aServiceSeed );
+            // Fixed seed nodes get our standard services bits set, this is after creating a CService obj with port 0,
+            // and a CNetAddr obj, where setspecial is called given the I2P Destination string so it is setup correctly
+            // with our new GarlicCat value for routing...
+            CAddress addr( CService( CNetAddr( I2pSeedAddresses[i] ), 0 ), NODE_NETWORK | NODE_BLOOM | NODE_I2P );
             addr.nTime = GetTime() - GetRand(nOneWeek) - nOneWeek;
             vFixedSeeds.push_back(addr);
         }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -59,7 +59,6 @@ public:
         vOldAlertPubKey = ParseHex("04b2941a448ab9860beb73fa2f600c09bf9fe4d18d5ff0b3957bf94c6d177d61f88660d7c0dd9adef984080ddea03c898039759f66c2011c111c4394692f814962");
 
         nDefaultPort = 9377;
-        nRPCPort = 9376;
 
         // As of March '15, SCRYPT is all that matters, future mining with a SHA256D algo may soon be supported as well, set those limits here.
         bnProofOfWorkLimit[ALGO_SCRYPT] = CBigNum().SetCompact(0x1e0ffff0);  // As defined in Anoncoin 8.6....
@@ -169,8 +168,6 @@ public:
     }
 
     virtual const CBlock& GenesisBlock() const { return genesis; }
-    virtual Network NetworkID() const { return CChainParams::MAIN; }
-
     virtual const vector<CAddress>& FixedSeeds() const { return vFixedSeeds; }
 protected:
     CBlock genesis;
@@ -196,7 +193,6 @@ public:
         pchMessageStart[3] = 0x4b;
 
         strNetworkID = "testnet";
-        strDataDir = "testnet";
 
         // GR Note: 1/26/2015 - New secp256k1 key values generated for testnet....
         vAlertPubKey = ParseHex("0442ccd085e52f7b74ee594826e36e417706af91ff7e7236a430b2dd16fe9f1a8132d0718e0bf5a3b7105354bf5bf954330097b21824c26c466836df9538f3d33e");
@@ -204,7 +200,6 @@ public:
         // "3082011302010104204b164c9765248427d1b13b9dc4f11107629485f0c61de070d89ebae308822e25a081a53081a2020101302c06072a8648ce3d0101022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f300604010004010704410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141020101a1440342000442ccd085e52f7b74ee594826e36e417706af91ff7e7236a430b2dd16fe9f1a8132d0718e0bf5a3b7105354bf5bf954330097b21824c26c466836df9538f3d33e"
 
         nDefaultPort = 19377;
-        nRPCPort = 19376;
 
         // ToDo: Proof of work limits for testnet.  Adjust as needed...
         bnProofOfWorkLimit[ALGO_SCRYPT] = CBigNum(~uint256(0) >> 17);
@@ -235,7 +230,6 @@ public:
         base58Prefixes[EXT_PUBLIC_KEY] = list_of(0x04)(0x35)(0x87)(0xCF);
         base58Prefixes[EXT_SECRET_KEY] = list_of(0x04)(0x35)(0x83)(0x94);
     }
-    virtual Network NetworkID() const { return CChainParams::TESTNET; }
 };
 // Keep in mind, this is a class derived from CMainParams which is derived from CChainParams.  If your trying to debug startup code
 // you will see, the CMainParams object created twice, first from the creation of the static variable mainParams (above), then the
@@ -250,7 +244,6 @@ class CRegTestParams : public CTestNetParams {
 public:
     CRegTestParams() {
         strNetworkID = "regtest";
-        strDataDir = "regtest";
 
         pchMessageStart[0] = 0xfa;
         pchMessageStart[1] = 0xbf;
@@ -266,7 +259,6 @@ public:
         genesis.nNonce = 2;
         hashGenesisBlock = genesis.GetHash();
         nDefaultPort = 19444;
-        nRPCPort = 19443;
 
         // printf("RegTest Genesis Hash: %s, nBits: %08x, bnLimt: %08x \n", hashGenesisBlock.ToString().c_str(), genesis.nBits, bnProofOfWorkLimit[ALGO_SCRYPT].GetCompact());
         assert(hashGenesisBlock == uint256("0x03ab995e27af2435ad33284ccb89095e6abe47d0846a4e8c34a3d0fc2d167ceb"));
@@ -275,7 +267,6 @@ public:
     }
 
     virtual bool RequireRPCPassword() const { return false; }
-    virtual Network NetworkID() const { return CChainParams::REGTEST; }
 };
 
 // Keep in mind, this is a class derived from CTestNetParams which is derived from CMainParams which is derived from CChainParams.
@@ -292,21 +283,23 @@ const CChainParams &Params() {
     return *pCurrentParams;
 }
 
-void SelectParams(CChainParams::Network network) {
+CChainParams &Params(CBaseChainParams::Network network) {
     switch (network) {
-        case CChainParams::MAIN:
-            pCurrentParams = &mainParams;
-            break;
-        case CChainParams::TESTNET:
-            pCurrentParams = &testNetParams;
-            break;
-        case CChainParams::REGTEST:
-            pCurrentParams = &regTestParams;
-            break;
+        case CBaseChainParams::MAIN:
+            return mainParams;
+        case CBaseChainParams::TESTNET:
+            return testNetParams;
+        case CBaseChainParams::REGTEST:
+            return regTestParams;
         default:
             assert(false && "Unimplemented network");
-            return;
+            return mainParams;
     }
+}
+
+void SelectParams(CBaseChainParams::Network network) {
+    SelectBaseParams(network);
+    pCurrentParams = &Params(network);
 }
 
 bool SelectParamsFromCommandLine() {
@@ -318,11 +311,11 @@ bool SelectParamsFromCommandLine() {
     }
 
     if (fRegTest) {
-        SelectParams(CChainParams::REGTEST);
+        SelectParams(CBaseChainParams::REGTEST);
     } else if (fTestNet) {
-        SelectParams(CChainParams::TESTNET);
+        SelectParams(CBaseChainParams::TESTNET);
     } else {
-        SelectParams(CChainParams::MAIN);
+        SelectParams(CBaseChainParams::MAIN);
     }
     return true;
 }

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -3,7 +3,6 @@
 // Copyright (c) 2013-2015 The Anoncoin Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
 #ifndef ANONCOIN_CHAIN_PARAMS_H
 #define ANONCOIN_CHAIN_PARAMS_H
 
@@ -68,7 +67,6 @@ public:
     enum MinedWithAlgo {
         ALGO_SCRYPT,             // Anoncoin native is this, always needs to be the default, and compatible with blocks on the chain from genesis onward...
         ALGO_SHA256D,
-        ALGO_PRIME,
 
         MAX_ALGO_TYPES
     };
@@ -76,6 +74,7 @@ public:
     const uint256& HashGenesisBlock() const { return hashGenesisBlock; }
     const MessageStartChars& MessageStart() const { return pchMessageStart; }
     const vector<unsigned char>& AlertKey() const { return vAlertPubKey; }
+    const vector<unsigned char>& OldAlertKey() const { return vOldAlertPubKey; }
     int GetDefaultPort() const { return nDefaultPort; }
     const CBigNum& ProofOfWorkLimit( MinedWithAlgo mwa = ALGO_SCRYPT ) const { return bnProofOfWorkLimit[ mwa ]; }
     virtual const CBlock& GenesisBlock() const = 0;
@@ -97,6 +96,7 @@ protected:
     MessageStartChars pchMessageStart;
     // Raw pub key bytes for the broadcast alert signing key.
     vector<unsigned char> vAlertPubKey;
+    vector<unsigned char> vOldAlertPubKey;
     int nDefaultPort;
     int nRPCPort;
     CBigNum bnProofOfWorkLimit[ MAX_ALGO_TYPES ];
@@ -132,5 +132,5 @@ inline bool TestNet() {
 inline bool RegTest() {
     return Params().NetworkID() == CChainParams::REGTEST;
 }
+#endif // header guard
 
-#endif

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -14,6 +14,7 @@
 #include "config/anoncoin-config.h"
 #endif
 
+#include "chainparamsbase.h"
 #include "bignum.h"
 #include "uint256.h"
 
@@ -46,14 +47,6 @@ struct CDNSSeedData {
 class CChainParams
 {
 public:
-    enum Network {
-        MAIN,
-        TESTNET,
-        REGTEST,
-
-        MAX_NETWORK_TYPES
-    };
-
     enum Base58Type {
         PUBKEY_ADDRESS,
         SCRIPT_ADDRESS,
@@ -80,7 +73,6 @@ public:
     virtual const CBlock& GenesisBlock() const = 0;
     virtual bool RequireRPCPassword() const { return true; }
     const string& DataDir() const { return strDataDir; }
-    virtual Network NetworkID() const = 0;
     std::string NetworkIDString() const { return strNetworkID; }
     const vector<CDNSSeedData>& DNSSeeds() const { return vSeeds; }
 #ifdef ENABLE_I2PSAM
@@ -88,7 +80,6 @@ public:
 #endif
     const std::vector<unsigned char> &Base58Prefix(Base58Type type) const { return base58Prefixes[type]; }
     virtual const vector<CAddress>& FixedSeeds() const = 0;
-    int RPCPort() const { return nRPCPort; }
 protected:
     CChainParams() {}
 
@@ -98,7 +89,6 @@ protected:
     vector<unsigned char> vAlertPubKey;
     vector<unsigned char> vOldAlertPubKey;
     int nDefaultPort;
-    int nRPCPort;
     CBigNum bnProofOfWorkLimit[ MAX_ALGO_TYPES ];
     string strDataDir;
     vector<CDNSSeedData> vSeeds;
@@ -115,8 +105,11 @@ protected:
  */
 const CChainParams &Params();
 
+/** Return parameters for the given network. */
+CChainParams &Params(CBaseChainParams::Network network);
+
 /** Sets the params returned by Params() to those for the given network. */
-void SelectParams(CChainParams::Network network);
+void SelectParams(CBaseChainParams::Network network);
 
 /**
  * Looks for -regtest or -testnet and then calls SelectParams as appropriate.
@@ -126,11 +119,11 @@ bool SelectParamsFromCommandLine();
 
 inline bool TestNet() {
     // Note: it's deliberate that this returns "false" for regression test mode.
-    return Params().NetworkID() == CChainParams::TESTNET;
+    return BaseParams().NetworkID() == CBaseChainParams::TESTNET;
 }
 
 inline bool RegTest() {
-    return Params().NetworkID() == CChainParams::REGTEST;
+    return BaseParams().NetworkID() == CBaseChainParams::REGTEST;
 }
 #endif // header guard
 

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -1,0 +1,123 @@
+// Copyright (c) 2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin Core developers
+// Copyright (c) 2013-2015 The Anoncoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "chainparamsbase.h"
+
+#include "util.h"
+
+#include <assert.h>
+
+/**
+ * Main network
+ */
+class CBaseMainParams : public CBaseChainParams
+{
+public:
+    CBaseMainParams()
+    {
+        nRPCPort = 9376;
+    }
+    virtual Network NetworkID() const { return CBaseChainParams::MAIN; }
+};
+static CBaseMainParams mainParams;
+
+/**
+ * Testnet
+ */
+class CBaseTestNetParams : public CBaseMainParams
+{
+public:
+    CBaseTestNetParams()
+    {
+        nRPCPort = 19376;
+        strDataDir = "testnet";
+    }
+    virtual Network NetworkID() const { return CBaseChainParams::TESTNET; }
+};
+static CBaseTestNetParams testNetParams;
+
+/*
+ * Regression test
+ */
+class CBaseRegTestParams : public CBaseTestNetParams
+{
+public:
+    CBaseRegTestParams()
+    {
+        nRPCPort = 19443;
+        strDataDir = "regtest";
+    }
+    virtual Network NetworkID() const { return CBaseChainParams::REGTEST; }
+};
+static CBaseRegTestParams regTestParams;
+
+/*
+ * Unit test
+ */
+class CBaseUnitTestParams : public CBaseMainParams
+{
+public:
+    CBaseUnitTestParams()
+    {
+        strDataDir = "unittest";
+    }
+};
+static CBaseUnitTestParams unitTestParams;
+
+static CBaseChainParams* pCurrentBaseParams = 0;
+
+const CBaseChainParams& BaseParams()
+{
+    assert(pCurrentBaseParams);
+    return *pCurrentBaseParams;
+}
+
+void SelectBaseParams(CBaseChainParams::Network network)
+{
+    switch (network) {
+    case CBaseChainParams::MAIN:
+        pCurrentBaseParams = &mainParams;
+        break;
+    case CBaseChainParams::TESTNET:
+        pCurrentBaseParams = &testNetParams;
+        break;
+    case CBaseChainParams::REGTEST:
+        pCurrentBaseParams = &regTestParams;
+        break;
+    default:
+        assert(false && "Unimplemented network");
+        return;
+    }
+}
+
+CBaseChainParams::Network NetworkIdFromCommandLine()
+{
+    bool fRegTest = GetBoolArg("-regtest", false);
+    bool fTestNet = GetBoolArg("-testnet", false);
+
+    if (fTestNet && fRegTest)
+        return CBaseChainParams::MAX_NETWORK_TYPES;
+    if (fRegTest)
+        return CBaseChainParams::REGTEST;
+    if (fTestNet)
+        return CBaseChainParams::TESTNET;
+    return CBaseChainParams::MAIN;
+}
+
+bool SelectBaseParamsFromCommandLine()
+{
+    CBaseChainParams::Network network = NetworkIdFromCommandLine();
+    if (network == CBaseChainParams::MAX_NETWORK_TYPES)
+        return false;
+
+    SelectBaseParams(network);
+    return true;
+}
+
+bool AreBaseParamsConfigured()
+{
+    return pCurrentBaseParams != NULL;
+}

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -1,0 +1,65 @@
+// Copyright (c) 2014 The Bitcoin Core developers
+// Copyright (c) 2013-2015 The Anoncoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef ANONCOIN_CHAINPARAMSBASE_H
+#define ANONCOIN_CHAINPARAMSBASE_H
+
+#include <string>
+#include <vector>
+
+/**
+ * CBaseChainParams defines the base parameters (shared between anoncoin-cli and anoncoind)
+ * of a given instance of the Anoncoin system.
+ */
+class CBaseChainParams
+{
+public:
+    enum Network {
+        MAIN,
+        TESTNET,
+        REGTEST,
+
+        MAX_NETWORK_TYPES
+    };
+
+    const std::string& DataDir() const { return strDataDir; }
+    int RPCPort() const { return nRPCPort; }
+    virtual Network NetworkID() const = 0;
+
+protected:
+    CBaseChainParams() {}
+
+    int nRPCPort;
+    std::string strDataDir;
+};
+
+/**
+ * Return the currently selected parameters. This won't change after app startup
+ * outside of the unit tests.
+ */
+const CBaseChainParams& BaseParams();
+
+/** Sets the params returned by Params() to those for the given network. */
+void SelectBaseParams(CBaseChainParams::Network network);
+
+/**
+ * Looks for -regtest or -testnet and returns the appropriate Network ID.
+ * Returns MAX_NETWORK_TYPES if an invalid combination is given.
+ */
+CBaseChainParams::Network NetworkIdFromCommandLine();
+
+/**
+ * Calls NetworkIdFromCommandLine() and then calls SelectParams as appropriate.
+ * Returns false if an invalid combination is given.
+ */
+bool SelectBaseParamsFromCommandLine();
+
+/**
+ * Return true if SelectBaseParamsFromCommandLine() has been called to select
+ * a network.
+ */
+bool AreBaseParamsConfigured();
+
+#endif // ANONCOIN_CHAINPARAMSBASE_H

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -85,9 +85,9 @@ namespace Checkpoints
     };
 
     const CCheckpointData &Checkpoints() {
-        if (Params().NetworkID() == CChainParams::TESTNET)
+        if (BaseParams().NetworkID() == CBaseChainParams::TESTNET)
             return dataTestnet;
-        else if (Params().NetworkID() == CChainParams::MAIN)
+        else if (BaseParams().NetworkID() == CBaseChainParams::MAIN)
             return data;
         else
             return dataRegtest;

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -60,26 +60,28 @@ namespace Checkpoints
         7000.0     // * estimated number of transactions per day after checkpoint
     };
 
+    // Testnet or RegTest checkpoints, same as the genesis block, est. tx/day = 480 blocks x 1 transaction
     static MapCheckpoints mapCheckpointsTestnet =
         boost::assign::map_list_of
-        ( 546, uint256("0xa0fea99a6897f531600c8ae53367b126824fd6a847b2b2b73817a95b8e27e602"))
+        ( 0, uint256("0x66d320494074f837363642a0c848ead1dbbbc9f7b854f8cda1f3eabbf08eb48c"))
         ;
     static const CCheckpointData dataTestnet = {
         &mapCheckpointsTestnet,
-        1365458829,
-        547,
-        576
+        1373625296,
+        0,
+        480
     };
 
+    // Initial checkpoint map for Anoncoin Regression tests is the genesis block
     static MapCheckpoints mapCheckpointsRegtest =
         boost::assign::map_list_of
-        ( 0, uint256("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"))
+        ( 0, uint256("0x03ab995e27af2435ad33284ccb89095e6abe47d0846a4e8c34a3d0fc2d167ceb"))
         ;
     static const CCheckpointData dataRegtest = {
         &mapCheckpointsRegtest,
+        1296688602,
         0,
-        0,
-        0
+        480
     };
 
     const CCheckpointData &Checkpoints() {

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -2,7 +2,6 @@
 // Copyright (c) 2013-2015 The Anoncoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
 #ifndef ANONCOIN_CLIENTVERSION_H
 #define ANONCOIN_CLIENTVERSION_H
 
@@ -24,7 +23,7 @@
 #define CLIENT_VERSION_MAJOR       0
 #define CLIENT_VERSION_MINOR       9
 #define CLIENT_VERSION_REVISION    4
-#define CLIENT_VERSION_BUILD       4
+#define CLIENT_VERSION_BUILD       5
 
 // Set to true for release, false for prerelease or test build
 #define CLIENT_VERSION_IS_RELEASE  false
@@ -36,19 +35,6 @@
 #define COPYRIGHT_YEAR 2015
 
 #endif //HAVE_CONFIG_H
-
-// Regardless of HAVE_CONFIG_H's state, these need to be declared, if they are not already.
-//
-// primecoin client version - ToDo: GR note - Needs review - copied these in so anc will compile the 'developer' branch.
-//                                            They should go here though, for ease in future upgrades.  IMO LightCoin should also be listed
-#if !defined(HAVE_PRIMECOIN_CONFIG_H)
-#define HAVE_PRIMECOIN_CONFIG_H
-
-#define PRIMECOIN_VERSION_MAJOR 0
-#define PRIMECOIN_VERSION_MINOR 1
-#define PRIMECOIN_VERSION_REVISION 2
-#define PRIMECOIN_VERSION_BUILD 0
-#endif
 
 /**
  * Converts the parameter X to a string after macro replacement on X has been performed.
@@ -85,11 +71,6 @@ extern const std::string CLIENT_DATE;
 std::string FormatFullVersion();
 std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments);
 
-static const int PRIMECOIN_VERSION =
-                           1000000 * PRIMECOIN_VERSION_MAJOR
-                         +   10000 * PRIMECOIN_VERSION_MINOR
-                         +     100 * PRIMECOIN_VERSION_REVISION
-                         +       1 * PRIMECOIN_VERSION_BUILD;
 
 #endif // WINDRES_PREPROC
 

--- a/src/core.h
+++ b/src/core.h
@@ -19,7 +19,7 @@ class CTransaction;
 /** No amount larger than this (in satoshi) is valid */
 // Original btc code: static const int64_t MAX_MONEY = 84000000 * COIN;
 // This value was set wrong in the the v0.8.5.6 client, v9 wallets starting with v9.4.5 builds use the following:
-static const int64_t MAX_MONEY = 3105155 * COIN;
+static const int64_t MAX_MONEY = 3105156 * COIN;
 
 inline bool MoneyRange(int64_t nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
 

--- a/src/core.h
+++ b/src/core.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2013 The Bitcoin developers
-// Copyright (c) 2013-2014 The Anoncoin Core developers
+// Copyright (c) 2013-2015 The Anoncoin Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -17,9 +17,10 @@
 class CTransaction;
 
 /** No amount larger than this (in satoshi) is valid */
-// This value is set to the same as used in the v0.8.5.6 client
 // Original btc code: static const int64_t MAX_MONEY = 84000000 * COIN;
-static const int64_t MAX_MONEY = 4200000 * COIN;
+// This value was set wrong in the the v0.8.5.6 client, v9 wallets starting with v9.4.5 builds use the following:
+static const int64_t MAX_MONEY = 3105155 * COIN;
+
 inline bool MoneyRange(int64_t nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
 
 /** An outpoint - a combination of a transaction hash and an index n into its vout */
@@ -484,5 +485,4 @@ struct CBlockLocator
         return vHave.empty();
     }
 };
-
-#endif
+#endif // header guard

--- a/src/i2pwrapper.cpp
+++ b/src/i2pwrapper.cpp
@@ -93,15 +93,15 @@ namespace SAM
 
     SAM::SOCKET StreamSessionAdapter::accept(bool silent)
     {
-        SAM::RequestResult<std::auto_ptr<SAM::Socket> > result = sessionHolder_->getSession().accept(silent);
-        // call Socket::release
+        SAM::RequestResult<std::auto_ptr<SAM::I2pSocket> > result = sessionHolder_->getSession().accept(silent);
+        // call I2pSocket::release
         return result.isOk ? result.value->release() : SAM_INVALID_SOCKET;
     }
 
     SAM::SOCKET StreamSessionAdapter::connect(const std::string& destination, bool silent)
     {
-        SAM::RequestResult<std::auto_ptr<SAM::Socket> > result = sessionHolder_->getSession().connect(destination, silent);
-        // call Socket::release
+        SAM::RequestResult<std::auto_ptr<SAM::I2pSocket> > result = sessionHolder_->getSession().connect(destination, silent);
+        // call I2pSocket::release
         return result.isOk ? result.value->release() : SAM_INVALID_SOCKET;
     }
 

--- a/src/i2pwrapper.h
+++ b/src/i2pwrapper.h
@@ -82,11 +82,13 @@ class I2PSession : private SAM::StreamSessionAdapter
 };
 
 void InitializeI2pSettings( void );
+bool isValidI2pDestination( const SAM::FullDestination& DestKeys );
 std::string GetDestinationPublicKey( const std::string& sDestinationPrivateKey );
 bool isValidI2pAddress( const std::string& I2pAddr );
-bool isValidI2pDestination( const SAM::FullDestination& DestKeys );
 bool isValidI2pB32( const std::string& B32Address );
+bool isStringI2pDestination( const std::string & strName );
 std::string B32AddressFromDestination(const std::string& destination);
+uint256 GetI2pDestinationHash( const std::string& destination );
 
 /**
  * Specific functions we need to implement I2P functionality

--- a/src/i2pwrapper.h
+++ b/src/i2pwrapper.h
@@ -88,4 +88,14 @@ bool isValidI2pDestination( const SAM::FullDestination& DestKeys );
 bool isValidI2pB32( const std::string& B32Address );
 std::string B32AddressFromDestination(const std::string& destination);
 
+/**
+ * Specific functions we need to implement I2P functionality
+ */
+std::string FormatI2PNativeFullVersion();
+bool IsDarknetOnly();
+bool IsTorOnly();
+bool IsI2POnly();
+bool IsI2PEnabled();
+bool IsBehindDarknet();
+
 #endif // I2PWRAPPER_H

--- a/src/i2pwrapper.h
+++ b/src/i2pwrapper.h
@@ -98,4 +98,15 @@ bool IsI2POnly();
 bool IsI2PEnabled();
 bool IsBehindDarknet();
 
+struct Identity
+{
+    uint8_t publicKey[256];
+    uint8_t signingKey[128];
+    struct
+    {
+        uint8_t type;
+        uint16_t length;
+    } certificate;
+};
+
 #endif // I2PWRAPPER_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -236,7 +236,7 @@ std::string HelpMessage(HelpMessageMode hmm)
     strUsage += "  -maxsendbuffer=<n>     " + _("Maximum per-connection send buffer, <n>*1000 bytes (default: 1000)") + "\n";
     strUsage += "  -onion=<ip:port>       " + _("Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)") + "\n";
     strUsage += "  -onlynet=<net>         " + _("Only connect to nodes in network <net> (ipv4, ipv6, onion or i2p)") + "\n";
-    strUsage += "  -port=<port>           " + _("Listen for connections on <port> (default: 9333 or testnet: 19333)") + "\n";
+    strUsage += "  -port=<port>           " + _("Listen for connections on <port> (default: 9377 or testnet: 19377)") + "\n";
     strUsage += "  -proxy=<ip:port>       " + _("Connect through SOCKS5 proxy") + "\n";
     strUsage += "  -seednode=<ip>         " + _("Connect to a node to retrieve peer addresses, and disconnect") + "\n";
     strUsage += "  -timeout=<n>           " + _("Specify connection timeout in milliseconds (default: 20000)") + "\n";
@@ -319,7 +319,7 @@ std::string HelpMessage(HelpMessageMode hmm)
     strUsage += "  -server                " + _("Accept command line and JSON-RPC commands") + "\n";
     strUsage += "  -rpcuser=<user>        " + _("Username for JSON-RPC connections") + "\n";
     strUsage += "  -rpcpassword=<pw>      " + _("Password for JSON-RPC connections") + "\n";
-    strUsage += "  -rpcport=<port>        " + _("Listen for JSON-RPC connections on <port> (default: 9332 or testnet: 19332)") + "\n";
+    strUsage += "  -rpcport=<port>        " + _("Listen for JSON-RPC connections on <port> (default: 9376 or testnet: 19376)") + "\n";
     strUsage += "  -rpcallowip=<ip>       " + _("Allow JSON-RPC connections from specified IP address") + "\n";
     strUsage += "  -rpcthreads=<n>        " + _("Set the number of threads to service RPC calls (default: 4)") + "\n";
 
@@ -792,7 +792,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     bool fGenI2pDest = GetBoolArg("-generatei2pdestination", false);
     if( fGenI2pDest ) {                                             // Hard set these 2 values
         mapArgs[ "-i2p.options.enabled" ] = "1";
-        mapArgs[ "-i2p.options.static" ] = "0";
+        mapArgs[ "-i2p.mydestination.static" ] = "0";
     }
 
     // Initialize some stuff here alittle early, so if GenI2pDest is run, they will be setup with
@@ -812,7 +812,7 @@ bool AppInit2(boost::thread_group& threadGroup)
         // Now we can either use a static destination address, taken from anoncoin.conf values to create a Stream Session, or
         // generate a dynamic new one and initiate an I2P session stream that way...
         SAM::FullDestination retI2pKeys;                                        // Something we can compare our results too
-        if( GetBoolArg( "-i2p.options.static", false ) ) {      // Running static mode, if this is true, upto the user to make sure our destination has been set
+        if( GetBoolArg( "-i2p.mydestination.static", false ) ) {      // Running static mode, if this is true, upto the user to make sure our destination has been set
             LogPrintf( "Attempting to create an I2P Sam session.  With a static destination...\n" );
             if( isValidI2pDestination( myI2pKeys ) ) {          // Here we check to make sure the values look right
                 retI2pKeys = I2PSession::Instance().getMyDestination();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -129,6 +129,9 @@ void Shutdown()
 #endif
     StopNode();
     UnregisterNodeSignals(GetNodeSignals());
+#ifdef ENABLE_I2PSAM
+    if( IsI2PEnabled() ) I2PSession::Instance().stopForwardingAll();
+#endif
     {
         LOCK(cs_main);
 #ifdef ENABLE_WALLET

--- a/src/main.h
+++ b/src/main.h
@@ -114,6 +114,9 @@ extern unsigned int nCoinCacheSize;
 // Minimum disk space required - used in CheckDiskSpace()
 static const uint64_t nMinDiskSpace = 52428800;
 
+// Anoncoin target block time in seconds is 3 minutes * 60 secs/min, has been since KGW era...
+static const int64_t nTargetSpacing = 180;
+
 
 class CCoinsDB;
 class CBlockTreeDB;

--- a/src/main.h
+++ b/src/main.h
@@ -173,6 +173,9 @@ bool SendMessages(CNode* pto, bool fSendTrickle);
 void ThreadScriptCheck();
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */
 bool CheckProofOfWork(uint256 hash, unsigned int nBits);
+/** Return the difficulty calculation, if no index is given, it attempts to use the active chain tip */
+double GetDifficulty(const CBlockIndex* blockindex = NULL);
+
 /** Calculate the minimum amount of work a received block needs, without knowing its direct parent */
 unsigned int ComputeMinWork(unsigned int nBase, int64_t nTime);
 /** Check whether we are doing an initial block download (synchronizing from disk or network) */

--- a/src/main2.cpp
+++ b/src/main2.cpp
@@ -495,3 +495,35 @@ void UpdateTime(CBlockHeader& block, const CBlockIndex* pindexPrev)
         // block.nBits = GetNextWorkRequired(pindexPrev, &block);
 }
 
+double GetDifficulty(const CBlockIndex* blockindex)
+{
+    // Floating point number that is a multiple of the minimum difficulty,
+    // minimum difficulty = 1.0.
+    if (blockindex == NULL)
+    {
+        if (chainActive.Tip() == NULL)
+            return 1.0;
+        else
+            blockindex = chainActive.Tip();
+    }
+
+    int nShift = (blockindex->nBits >> 24) & 0xff;
+
+    double dDiff =
+        (double)0x0000ffff / (double)(blockindex->nBits & 0x00ffffff);
+
+    while (nShift < 29)
+    {
+        dDiff *= 256.0;
+        nShift++;
+    }
+    while (nShift > 29)
+    {
+        dDiff /= 256.0;
+        nShift--;
+    }
+
+    return dDiff;
+}
+
+

--- a/src/main2.cpp
+++ b/src/main2.cpp
@@ -3,16 +3,13 @@
 //       Then develop the associated build script updates so it compiles & links in with everything else...
 //
 
-// #define LOG_DIFFICULTY_RETARGETING
+// #define LOG_DEBUG_OUTPUT
 
-// This value define the Anoncoin block rate production, difficulty calculations and Proof Of Work functions should use this as the goal...
-static const int64_t nTargetSpacing = 180;      // in Seconds - Anoncoin target block time since KGW era, is 3 minutes * 60 secs/min
-static const int64_t nTargetTimespan = 86184;   // in Seconds - Anoncoin legacy value is ~23.94hrs, it came from a
-                                                // 420 blocks * 205.2 seconds/block calculation, now used in orignal
-                                                // NextWorkRequired & ComputeMinWork functions.
+// This value defines the Anoncoin block rate production, difficulty calculations and Proof Of Work functions should use this as the goal...
+// nTargetSpacing = 180;      and the definition has been moved to main.h for global visibility
 
 // Difficulty Protocols have changed over time, at specific points in Anoncoin's history
-// the following SwitchHeight values are those blocks where an event occured which
+// the following SwitchHeight values are those blocks where an event occurred which
 // required changing in the way things were calculated. aka HARDFORK
 static const int nDifficultySwitchHeight = 15420;   // Protocol 1 happened here
 static const int nDifficultySwitchHeight2 = 77777;  // Protocol 2 starts at this block
@@ -29,7 +26,9 @@ static const int nDifficultySwitchHeight4 = HARDFORK_BLOCK;
 unsigned int static OldGetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const CBigNum &bnProofOfWorkLimit)
 {
     // These legacy values define the Anoncoin block rate production and are used in this difficulty calculation only...
-    static const int64_t nTargetSpacingLegacy = 205;        // Originally 3.42 minutes * 60 secs was Anoncoin spacing target in seconds
+    static const int64_t nLegacyTargetSpacing = 205;    // Originally 3.42 minutes * 60 secs was Anoncoin spacing target in seconds
+    static const int64_t nLegacyTargetTimespan = 86184; // in Seconds - Anoncoin legacy value is ~23.94hrs, it came from a
+                                                        // 420 blocks * 205.2 seconds/block calculation, now used only in original NextWorkRequired function.
 
     if (pindexLast == NULL)                                 // If the last block was the Genesis block, we're done
         return bnProofOfWorkLimit.GetCompact();
@@ -39,7 +38,7 @@ unsigned int static OldGetNextWorkRequired(const CBlockIndex* pindexLast, const 
     int nHeight = pindexLast->nHeight + 1;
     bool fNewDifficultyProtocol = nHeight >= nDifficultySwitchHeight;
     bool fNewDifficultyProtocol2 = false;
-    int64_t nTargetTimespanCurrent = nTargetTimespan;
+    int64_t nTargetTimespanCurrent = nLegacyTargetTimespan;
     int64_t nLegacyInterval;
 
     if( nHeight >= nDifficultySwitchHeight2 ) {         // Jump back to sqrt(2) as the factor of adjustment.
@@ -49,10 +48,10 @@ unsigned int static OldGetNextWorkRequired(const CBlockIndex* pindexLast, const 
 
     if( fNewDifficultyProtocol ) nTargetTimespanCurrent *= 4;
     if (fNewDifficultyProtocol2) nTargetTimespanCurrent = newTargetTimespan;
-    nLegacyInterval = nTargetTimespanCurrent / nTargetSpacingLegacy;
+    nLegacyInterval = nTargetTimespanCurrent / nLegacyTargetSpacing;
 
     // Only change once per interval, or at protocol switch height
-    if( nHeight % nInterval != 0 && !fNewDifficultyProtocol2 && nHeight != nDifficultySwitchHeight )
+    if( nHeight % nLegacyInterval != 0 && !fNewDifficultyProtocol2 && nHeight != nDifficultySwitchHeight )
         return pindexLast->nBits;
 
     // Anoncoin: This fixes an issue where a 51% attack can change difficulty at will.
@@ -69,39 +68,39 @@ unsigned int static OldGetNextWorkRequired(const CBlockIndex* pindexLast, const 
     assert(pindexFirst);
 
     // Limit adjustment step
-    int64_t nActualTimespan = pindexLast->GetBlockTime() - pindexFirst->GetBlockTime();
-    int64_t nActualTimespanMax = fNewDifficultyProtocol ? (nTargetTimespanCurrent*4) : ((nTargetTimespanCurrent*99)/70);
-    int64_t nActualTimespanMin = fNewDifficultyProtocol ? (nTargetTimespanCurrent/4) : ((nTargetTimespanCurrent*70)/99);
+    int64_t nNewSetpoint = pindexLast->GetBlockTime() - pindexFirst->GetBlockTime();
+    int64_t nAveragedTimespanMax = fNewDifficultyProtocol ? (nTargetTimespanCurrent*4) : ((nTargetTimespanCurrent*99)/70);
+    int64_t nAveragedTimespanMin = fNewDifficultyProtocol ? (nTargetTimespanCurrent/4) : ((nTargetTimespanCurrent*70)/99);
     if (pindexLast->nHeight+1 >= nDifficultySwitchHeight2) {
-        if (nActualTimespan < nActualTimespanMin)
-            nActualTimespan = nActualTimespanMin;
-        if (nActualTimespan > nActualTimespanMax)
-            nActualTimespan = nActualTimespanMax;
+        if (nNewSetpoint < nAveragedTimespanMin)
+            nNewSetpoint = nAveragedTimespanMin;
+        if (nNewSetpoint > nAveragedTimespanMax)
+            nNewSetpoint = nAveragedTimespanMax;
     } else if (pindexLast->nHeight+1 > nDifficultySwitchHeight) {
-        if (nActualTimespan < nActualTimespanMin/4)
-            nActualTimespan = nActualTimespanMin/4;
-        if (nActualTimespan > nActualTimespanMax)
-            nActualTimespan = nActualTimespanMax;
+        if (nNewSetpoint < nAveragedTimespanMin/4)
+            nNewSetpoint = nAveragedTimespanMin/4;
+        if (nNewSetpoint > nAveragedTimespanMax)
+            nNewSetpoint = nAveragedTimespanMax;
     } else {
-        if (nActualTimespan < nActualTimespanMin)
-            nActualTimespan = nActualTimespanMin;
-        if (nActualTimespan > nActualTimespanMax)
-            nActualTimespan = nActualTimespanMax;
+        if (nNewSetpoint < nAveragedTimespanMin)
+            nNewSetpoint = nAveragedTimespanMin;
+        if (nNewSetpoint > nAveragedTimespanMax)
+            nNewSetpoint = nAveragedTimespanMax;
     }
 
     // Retarget
     CBigNum bnNew;
     bnNew.SetCompact(pindexLast->nBits);
-    bnNew *= nActualTimespan;
-    bnNew /= fNewDifficultyProtocol2 ? nTargetTimespanCurrent : nTargetTimespan;
+    bnNew *= nNewSetpoint;
+    bnNew /= fNewDifficultyProtocol2 ? nTargetTimespanCurrent : nLegacyTargetTimespan;
     if (bnNew > bnProofOfWorkLimit) bnNew = bnProofOfWorkLimit;
 
     // debug print
-#if defined( LOG_DIFFICULTY_RETARGETING )
+#if defined( LOG_DEBUG_OUTPUT )
     LogPrintf("Difficulty Retarget - pre-Kimoto Gravity Well era\n");
-    LogPrintf("nTargetTimespan = %lld    nActualTimespan = %lld\n", nTargetTimespan, nActualTimespan);
-    LogPrintf("Before: %08x  %s\n", pindexLast->nBits, CBigNum().SetCompact(pindexLast->nBits).getuint256().ToString());
-    LogPrintf("After:  %08x  %s\n", bnNew.GetCompact(), bnNew.getuint256().ToString());
+    LogPrintf("  TargetTimespan = %lld    ActualTimespan = %lld\n", nLegacyTargetTimespan, nNewSetpoint);
+    LogPrintf("  Before: %08x  %s\n", pindexLast->nBits, CBigNum().SetCompact(pindexLast->nBits).getuint256().ToString());
+    LogPrintf("  After : %08x  %s\n", bnNew.GetCompact(), bnNew.getuint256().ToString());
 #endif
     return bnNew.GetCompact();
 }
@@ -174,35 +173,65 @@ unsigned int static GetNextWorkRequiredForKgw(const CBlockIndex* pindexLast, con
     if( bnNew > bnProofOfWorkLimit ) bnNew = bnProofOfWorkLimit;
 
     // debug print
-#if defined( LOG_DIFFICULTY_RETARGETING )
+#if defined( LOG_DEBUG_OUTPUT )
     LogPrintf("Difficulty Retarget - Kimoto Gravity Well era\n");
-    LogPrintf("PastRateAdjustmentRatio = %g\n", PastRateAdjustmentRatio);
-    LogPrintf("Before: %08x %s\n", BlockLastSolved->nBits, CBigNum().SetCompact(BlockLastSolved->nBits).getuint256().ToString().c_str());
-    LogPrintf("After: %08x %s\n", bnNew.GetCompact(), bnNew.getuint256().ToString().c_str());
+    LogPrintf("  PastRateAdjustmentRatio = %g\n", PastRateAdjustmentRatio);
+    LogPrintf("  Before: %08x %s\n", BlockLastSolved->nBits, CBigNum().SetCompact(BlockLastSolved->nBits).getuint256().ToString().c_str());
+    LogPrintf("  After : %08x %s\n", bnNew.GetCompact(), bnNew.getuint256().ToString().c_str());
 #endif
     return bnNew.GetCompact();
 }
 
+// K1773R and Cryptoslave eyes only...
+// It maybe that all these comments in the code below get deleted before posting it to github, leaving the readers to figure it out on their own,
+// have not made a decision on that yet.  Nor has this code yet been testnet'd by me here locally, we are fiddling with the values used and even considering the possibility
+// of switching to the mining of two algos, SHA256D in addition to Scrypt, have not looked into the hours required yet to complete that task, and implement a new version #3 block
+// type as proposed by the code below, the work done for that so far, is only the tip of the iceberg, as far as getting the full implementation of a new block header type to work
+// across the board...
+//
+// K1773R wanted you to see the link, and shortened text description below, when we last talked, it had not been discovered yet.  Cryptoslave found an important
+// explanation of why DigiByte has a larger value (16%) for decreasing the difficulty adjustment, than the limit imposed for increasing (8%) a difficulty
+// adjustment.  Until now, we could not figure out if it was a coding mistake, or why it seemed backwards.  The full link is definitely worth reading, if your
+// interested in the topic.
+//
 #if defined( HARDFORK_BLOCK )
+/***
+ * http://www.reddit.com/r/Digibyte/comments/213t7b/what_is_digishield_how_it_works_to_retarget/
+ *
+ * The secret to DigiShield is an asymmetrical approach to difficulty re-targeting. With DigiShield, the difficulty is allowed to decrease in larger movements
+ * than it is allowed to increase from block to block. This keeps a blockchain from getting "stuck" i.e., not finding the next block for several hours following
+ * a major drop in the net hash of coin. It is all a balancing act. You need to allow the difficulty to increase enough between blocks to catch up to a sudden
+ * spike in net hash, but not enough to accidentally send the difficulty sky high when two miners get lucky and find blocks back to back. The same thing occurs
+ * with difficulty decreases. Since it takes much longer to find the next block, you need to allow it to drop quicker than it increases.
+ *
+ * We found that the difficulty needed to be able to decrease by a larger magnitude than it was allowed to increase. When the difficulty was allowed to increase
+ * or decrease at the same rate with larger orders of magnitude, some very bad oscillations occurred along with some crazy high difficulties when two lucky blocks
+ * were found quickly back to back. The asymmetrical adjustments keep the difficulty from going to high to fast, but allow it to drop much quicker after a large
+ * hash down swing as it takes a much longer time to discover the next two blocks for the difficulty adjustment to occur.
+ * You don't want to let the difficulty go to high to fast, but you need to give it enough room to catch up quickly. The same thing goes with down swings, since
+ * it takes longer to discover new blocks you need to give it more room to go down, but not enough to send it to the floor.
+ *
+ **/
 
-//MultiAlgo Target updates, most all these values could just as well be defined as constants too...do
-#define MULTIALGO_AVERAGING_INTERVAL 10                                 // in blocks, ToDo: why not use nMedianTimeSpan?
-#define MULTIALGO_TARGET_SPACING CChainParams::MAX_ALGO_TYPES * (nTargetSpacing / 2)  // in seconds, Anoncoin with 3 algos = target spacing of 4.5 minute spacing
+// MultiAlgo Target contants.
+// #define ALGO_COUNT_BEING_USED CChainParams::MAX_ALGO_TYPES
+// static const int64_t nTargetTimespan = SECONDSPERDAY / 10;              // in Seconds, 8640  ToDo: Setting this to 1/10 of a day is arbitary, consider alternatives..
+// static const int64_t nInterval = nTargetTimespan / nTargetSpacing;      // in Blocks, 48
+// static const int64_t nLocalDifficultyAdjustment = 4;                 // Used in per algo diff adjs, as a percentage: 4%
+#define ALGO_COUNT_BEING_USED 1
+#define MULTIALGO_AVERAGING_INTERVAL (CBlockIndex::nMedianTimeSpan - 1)         // in blocks (10) This value is one less nMedianTimeSpan...
+#define MULTIALGO_TARGET_SPACING  ALGO_COUNT_BEING_USED * (nTargetSpacing/2)    // in seconds, Anoncoin with 1 algo = target spacing is 90 seconds
+                                                                                // Note: nTargetSpacing is defined elsewhere in the code as 180 seconds
 
-static const int64_t nInterval = nTargetTimespan / nTargetSpacing;      // New global constant for Multi-Algo calculations. Interval of 478.8 seconds or 7.98 minutes
-static const int64_t nAveragingTargetTimespan = MULTIALGO_AVERAGING_INTERVAL * MULTIALGO_TARGET_SPACING;
-static const int64_t nLocalDifficultyAdjustment = 4;                    // In percentage: 4% down, 16% up
-static const int64_t nMaxAdjustDownV3 = 16;                             // 16% adjustment down
-static const int64_t nMaxAdjustUpV3 = 8;                                // 8% adjustment up
-static const int64_t nMinActualTimespanV3 = nAveragingTargetTimespan * (100 - nMaxAdjustUpV3) / 100;
-static const int64_t nMaxActualTimespanV3 = nAveragingTargetTimespan * (100 + nMaxAdjustDownV3) / 100;
+static const int64_t nIntegratedTargetTimespan = MULTIALGO_AVERAGING_INTERVAL * MULTIALGO_TARGET_SPACING;   // in Seconds 10x2x90 = 1800 or 900 for 1 algo
+static const int64_t nIncreasingDifficultyLimit = ( nIntegratedTargetTimespan * (100 - 12) ) / 100;         // Adjustment limit per retarget can be 12%
+static const int64_t nDecreasingDifficultyLimit = ( nIntegratedTargetTimespan * (100 + 16) ) / 100;         // Adjustment limit per retarget can be 16%
 
 // New Block version type #3 definitions we'll be using
 enum BlockMinedWith {
     BLOCK_VERSION_DEFAULT        = 3,           // Merged mined blocks, up the default block version by one, to version #3, and default to algo SCRYPT
     BLOCK_VERSION_SHA256D        = (1 << 8) | 3,// The next byte up, now represents the algo this block was mined with, if zero then it was SCRYPT and simply is a version 3 block
-    BLOCK_VERSION_PRIME          = (2 << 8) | 3,// Code needs to now check though, as the upper bits could shed more light on the proof of work results.
-    BLOCK_VERSION_ALGOS          = (7 << 8) | 3 // This mask can be used to expose the 3 bits in the byte above version #, allowing for up to 7 more algos
+    BLOCK_VERSION_ALGOS          = (7 << 8) | 3 // This mask can be used to expose the 3 bits in the byte above version #, allowing for up to 7 algos
 };
 
 // GetAlgo takes the simple nVersion field (int), found in every block, and decides which Algo was used for it.
@@ -214,9 +243,7 @@ CChainParams::MinedWithAlgo GetAlgo(int nVersion)
     {
         case BLOCK_VERSION_SHA256D:
             mwa = CChainParams::ALGO_SHA256D;
-        case BLOCK_VERSION_PRIME:
-            mwa = CChainParams::ALGO_PRIME;
-        default: mwa = CChainParams::ALGO_SCRYPT;     // Version 1, 2 or anything else assume SCRYPT
+        default: mwa = CChainParams::ALGO_SCRYPT;     // Version 1, 2 or anything else, we set the Algo returned to SCRYPT
     }
     return mwa;
 }
@@ -229,8 +256,6 @@ std::string GetAlgoName(CChainParams::MinedWithAlgo Algo)
             return std::string("scrypt");
         case CChainParams::ALGO_SHA256D:
             return std::string("sha256d");
-        case CChainParams::ALGO_PRIME:
-            return std::string("prime");
     }
     return std::string("unknown");
 }
@@ -238,14 +263,17 @@ std::string GetAlgoName(CChainParams::MinedWithAlgo Algo)
 CChainParams::MinedWithAlgo GetBlockAlgo( const CBlockIndex* pIndex ) { return GetAlgo( pIndex->nVersion ); }
 /**
  * Here we hunt back in time from the given block index, to the newest block mined of the given algo,
- * if the block index search takes up to genesis or before the HARDFORK_BLOCK, then we know the algo was SCRYPT,
- * and can stop looking any further, if that was not the requested search.
+ * if the block index search takes us back to the genesis or before the HARDFORK_BLOCK, then we know the algo was SCRYPT,
+ * and can stop looking any further...
  */
 const CBlockIndex* GetLastBlockIndexForAlgo(const CBlockIndex* pindex, CChainParams::MinedWithAlgo mwa);
 
 const CBlockIndex* GetLastBlockIndexForAlgo(const CBlockIndex* pindex, CChainParams::MinedWithAlgo mwa)
 {
-    while( pindex && (pindex->nHeight > HARDFORK_BLOCK || mwa == CChainParams::ALGO_SCRYPT) )
+    // Here we walk back the linked block list, trying to find the newest one mined with the Algo parameter provided.
+    // As there were no other mined block types before the hardfork, its pointless to keep looking if that algo is
+    // not Scrypt...
+    while( pindex && (mwa == CChainParams::ALGO_SCRYPT || pindex->nHeight > HARDFORK_BLOCK) )
     {
         if( GetBlockAlgo( pindex ) == mwa )
             return pindex;
@@ -259,42 +287,64 @@ const CBlockIndex* GetLastBlockIndexForAlgo(const CBlockIndex* pindex, CChainPar
  */
 unsigned int static GetNextWorkRequiredAfterKgw(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const CBigNum &bnProofOfWorkLimit )
 {
-    CChainParams::MinedWithAlgo algo = CChainParams::ALGO_SCRYPT;
-    unsigned int nProofOfWorkLimit = bnProofOfWorkLimit.GetCompact();
-
-    if (pindexLast == NULL)                                 // If the last block was the Genesis block, we're done
-        return bnProofOfWorkLimit.GetCompact();
+    CChainParams::MinedWithAlgo algo = CChainParams::ALGO_SCRYPT;      // Temporary variable for now with just one algo
 
     // find first block in averaging interval
-    // Go back by what we want to be MULTIALGO_AVERAGING_INTERVAL blocks per algo
+    // Setup pindexFirst by going back until we point at the block which is MULTIALGO_AVERAGING_INTERVAL seconds ago, more algos multiplies this value by that interval
     const CBlockIndex* pindexFirst = pindexLast;
-
-    for (int i = 0; pindexFirst && i < CChainParams::MAX_ALGO_TYPES * MULTIALGO_AVERAGING_INTERVAL; i++)
+    for (int i = 0; pindexFirst && i < ALGO_COUNT_BEING_USED * MULTIALGO_AVERAGING_INTERVAL; i++)
         pindexFirst = pindexFirst->pprev;
 
-    const CBlockIndex* pindexPrevAlgo = GetLastBlockIndexForAlgo(pindexLast, algo);
-    if (pindexPrevAlgo == NULL || pindexFirst == NULL)
-        return nProofOfWorkLimit; // not enough blocks available
+    // Setup pPrevBlockSameAlgo to point at the last block mined with this Algo, for single algo mining this will be the previous block
+    // So this simply sets up pPrevBlockSameAlgo to point at the same pindexLast block.
+    const CBlockIndex* pPrevBlockSameAlgo = GetLastBlockIndexForAlgo(pindexLast, algo);
+    if( pindexFirst == NULL || pPrevBlockSameAlgo == NULL )         // Not must more we can do then...
+        return bnProofOfWorkLimit.GetCompact();                 // not enough blocks available
 
-    // Limit adjustment step
+    LogPrintf("AncSheild-P1v0.1 RETARGET: Integrating constants in seconds: TimeSpan=%lld, Difficulty UpLimit=%lld, DownLimit=%lld\n", nIntegratedTargetTimespan, nIncreasingDifficultyLimit, nDecreasingDifficultyLimit );
+
     // Use medians to prevent time-warp attacks
-    int64_t nActualTimespan = pindexLast->GetMedianTimePast() - pindexFirst->GetMedianTimePast();
+    // Basically we're setting up a controlled feedback loop here, based on integrating past block times & calculating a derivative on the rate of change,
+    // for a faster response time, while keeping each adjustment step within an upper and lower bounds limit.
+    //
+    // Here we calculate the Median time, using the most recent 11 blocks, and again for what it was before that. (aka ~ the last hour for Anoncoin and one algo)
+    // We take these two values & subtract them, to get the relative recent performance into an absolute term called nNewSetpoint, which we then proceed to finish calculating...
+    int64_t nLatestAvgMedian = pindexLast->GetMedianTimePast();
+    int64_t nOlderAvgMedian = pindexFirst->GetMedianTimePast();
+    int64_t nNewSetpoint = nLatestAvgMedian - nOlderAvgMedian;       // In a perfect world, nNewSetpoint should approach our target timespan
+    LogPrintf("  Integrated Setpoint = %lld using TimeMedian=%lld from block %d & TimeMedian=%lld from block %d\n", nNewSetpoint, nLatestAvgMedian, pindexLast->nHeight, nOlderAvgMedian, pindexFirst->nHeight);
 
-    nActualTimespan = nAveragingTargetTimespan + (nActualTimespan - nAveragingTargetTimespan)/6;
-    LogPrintf("  nActualTimespan = %d before bounds\n", nActualTimespan);
-    if (nActualTimespan < nMinActualTimespanV3)
-        nActualTimespan = nMinActualTimespanV3;
-    if (nActualTimespan > nMaxActualTimespanV3)
-        nActualTimespan = nMaxActualTimespanV3;
+    // This next line of code calculates the difference between the real timespan and the target timespan, as a signed +/- value, using fast integer math.
+    // Picking the right constant to scale this differential value (we are dividing the amount here by 2 with one algo) is a challenge.  We want the
+    // difficulty shield to have a fast response time as mining conditions change, yet not have it endlessly oscillate when mining difficulty would otherwise
+    // be running smooth.  To small of a value and the retarget will not response as fast as it could to a sudden change in mining difficulty, if the value
+    // is too large, it can easily cause it to always hit the upper bound, then snap to the lower bound limit and vise-versa.
+    int64_t nTimespanDiff = (nNewSetpoint - nIntegratedTargetTimespan) / (ALGO_COUNT_BEING_USED + 1);
+
+    // Here now we finally have a new target time that will bring our integrated average block time back to what it should be with the differential added.
+    nNewSetpoint = nIntegratedTargetTimespan + nTimespanDiff;
+    LogPrintf("  Differential = %lld secs & New Setpoint = %lld before bound limits applied\n", nTimespanDiff, nNewSetpoint );
+
+    // Limit adjustment step...
+    // Now we limit that new difficulty adjustment by a predetermined upper and lower maximum amount of possible adjustment for the next block's difficulty
+    // Under stressful mining difficulty changes, the values programmed will increase the difficulty twice as fast as it will decay back to a lower difficulty level.
+    if (nNewSetpoint < nIncreasingDifficultyLimit)
+        nNewSetpoint = nIncreasingDifficultyLimit;
+    if (nNewSetpoint > nDecreasingDifficultyLimit)
+        nNewSetpoint = nDecreasingDifficultyLimit;
 
     // Global retarget
     CBigNum bnNew;
-    bnNew.SetCompact(pindexPrevAlgo->nBits);
-    bnNew *= nActualTimespan;
-    bnNew /= nAveragingTargetTimespan;
+    // Start with what the previous block (of same algo) had for difficulty, multiply it by our new calculated setpoint timespan desired & divide by the target goal.
+    // that is our new difficulty, unless its less that what Anoncoin can allow as the absolute minimum difficulty on the network aka ProofOfWorkLimit
+    // This is done with bignums, upgrade to the new v10 arith_uint256 class is the plan...
+    bnNew.SetCompact(pPrevBlockSameAlgo->nBits);
+    bnNew *= nNewSetpoint;
+    bnNew /= nIntegratedTargetTimespan;
 
+#if ALGO_COUNT_BEING_USED > 1
     // Per-algo retarget
-    int nAdjustments = pindexPrevAlgo->nHeight - pindexLast->nHeight + CChainParams::MAX_ALGO_TYPES - 1;
+    int nAdjustments = pPrevBlockSameAlgo->nHeight - pindexLast->nHeight + CChainParams::MAX_ALGO_TYPES - 1;
     if (nAdjustments > 0)
     {
         for (int i = 0; i < nAdjustments; i++)
@@ -311,15 +361,16 @@ unsigned int static GetNextWorkRequiredAfterKgw(const CBlockIndex* pindexLast, c
             bnNew /= 100;
         }
     }
+#endif
 
     if( bnNew > bnProofOfWorkLimit ) bnNew = bnProofOfWorkLimit;
 
     // debug print
-// #if defined( LOG_DIFFICULTY_RETARGETING )
-    LogPrintf("Difficulty Retarget - post-Kimoto Gravity Well\n");
-    LogPrintf("nTargetTimespan = %d    nActualTimespan = %d\n", nTargetTimespan, nActualTimespan);
-    LogPrintf("Before: %08x  %s\n", pindexLast->nBits, CBigNum().SetCompact(pindexLast->nBits).getuint256().ToString().c_str());
-    LogPrintf("After: %08x %s\n", bnNew.GetCompact(), bnNew.getuint256().ToString().c_str());
+// #if defined( LOG_DEBUG_OUTPUT )
+    // LogPrintf("  nTargetTimespan = %lld    nNewSetpoint after bounds = %lld\n", nTargetTimespan, nNewSetpoint);
+    LogPrintf("  nNewSetpoint used after bounds = %lld\n", nNewSetpoint);
+    LogPrintf("  Before: %08x %s\n", pindexLast->nBits, CBigNum().SetCompact(pindexLast->nBits).getuint256().ToString().c_str());
+    LogPrintf("  After : %08x %s\n", bnNew.GetCompact(), bnNew.getuint256().ToString().c_str());
 // #endif
 
 	return bnNew.GetCompact();
@@ -344,11 +395,19 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     assert(pindexLast);
     if( TestNet() || pindexLast->nHeight > nDifficultySwitchHeight3 ) {
 #if defined( HARDFORK_BLOCK )
-        if( TestNet() || pindexLast->nHeight > nDifficultySwitchHeight4 ) {
-            return GetNextWorkRequiredAfterKgw(pindexLast, pblock, bnProofOfWorkLimit );
+        // For Testnet first we mine some default blocks.  These are forced to be spaced near or after our target timespan in miner.cpp
+        // regardless of the ProofOfWorkLimit initially set. This nHeight value has
+        // been choosen, to have enough blocks to start with, so that the new algo can look back in time, and at
+        // least have something to work with.
+        // Also doing it this way can be helpful for tuning the chainparam value picked as the limit,
+        // and/or the miners you will be using to testnet with.  We want things to start out in the right ball park with the first blocks generated....
+        if( TestNet() && pindexLast->nHeight <= 22 )
+            return bnProofOfWorkLimit.GetCompact();
+        if( pindexLast->nHeight > nDifficultySwitchHeight4 || TestNet() ) {             // Otherwise this new algo will happen at the hardfork block value you have set for mainnet.
+            return GetNextWorkRequiredAfterKgw(pindexLast, pblock, bnProofOfWorkLimit );// Or if we are running Testnet...
         } else
 #endif
-        return GetNextWorkRequiredForKgw(pindexLast, pblock, bnProofOfWorkLimit );
+            return GetNextWorkRequiredForKgw(pindexLast, pblock, bnProofOfWorkLimit );
     } else
         return OldGetNextWorkRequired(pindexLast, pblock, bnProofOfWorkLimit );
 }
@@ -401,29 +460,38 @@ bool CheckProofOfWork(uint256 hash, unsigned int nBits)
 //
 unsigned int ComputeMinWork(unsigned int nBase, int64_t nTime)
 {
-    // ToDo: Which Algo?  After merge mining begins, which coins ProofOfWorkLimit
-    // needs to be considered when evaluating minimum work requirements..
-    const CBigNum &bnProofOfWorkLimit = Params().ProofOfWorkLimit( CChainParams::ALGO_SCRYPT );
+    // ToDo: Need to print this out, and reload the bootstrap blockchain looking for references that call this in the debug.log file.
+    // at least through the last checkpoint, block 200K something..
+    return Params().ProofOfWorkLimit( CChainParams::ALGO_SCRYPT ).GetCompact();
+}
 
-    // Testnet has min-difficulty blocks
-    // after nTargetSpacing*2 time between blocks:
-    if( TestNet() && nTime > nTargetSpacing*2 )
-        return bnProofOfWorkLimit.GetCompact();
+void UpdateTime(CBlockHeader& block, const CBlockIndex* pindexPrev)
+{
+    static int64_t nLastReportTime = 0;
+    int64_t nMedianTimePast;
 
-    CBigNum bnResult;
-    bnResult.SetCompact(nBase);
-    while (nTime > 0 && bnResult < bnProofOfWorkLimit) {
-		// ToDo: Ask CryptoSlave about a possible change to this value, after Kgw ends
-		// on the Maximum adjustment amount. The following commented out equation maybe
-		// a better fit for the model we want to use...
-        //  bnResult = (bnResult * 100) / 50;
-
-        // Maximum 141% adjustment...
-        bnResult = (bnResult * 99) / 70;
-        // ... in best-case exactly 4-times-normal target time
-        nTime -= nTargetTimespan * 4;
+    if( pindexPrev->nHeight > CBlockIndex::nMedianTimeSpan ) {                    // This is needed for testnet, were the previous block starts out as the genesis
+        nMedianTimePast = pindexPrev->GetMedianTimePast();
+        block.nTime = max( nMedianTimePast+1, GetAdjustedTime() );
+    } else {
+        block.nTime = GetAdjustedTime();
+        nMedianTimePast = pindexPrev->GetBlockTime();               // This is only used for the reporting below, if needed
     }
-    if( bnResult > bnProofOfWorkLimit ) bnResult = bnProofOfWorkLimit;
-    return bnResult.GetCompact();
+
+    // Needless reporting of the the blocktime update is reduced to 1/10 of the target timespan (18secs) by this if...
+    if( block.nTime - nLastReportTime > 18 ) {
+        LogPrintf( (pindexPrev->nHeight <= CBlockIndex::nMedianTimeSpan) ? "New blocktime since last block %lld (blocks 1-11)\n" : "New blocktime since last median %lld\n", block.nTime - nMedianTimePast );
+        nLastReportTime = block.nTime;
+    }
+
+    // Updating time can change work required on testnet:
+    // That maybe true, have found that comment and this code in many other crypto coin sources,
+    // and if using an rpc call for testnet mining, to getwork or getblocktemplate, this may yet be required.
+    // For Anoncoin on testnet, initially here just using the built-in miner, which
+    // calls this code right after UpdateTime() is set, so using that to mine with this no longer makes sense to me.
+    // We can better control TestNet() operation there, than in this function....
+    // ToDo: yet to be determined if this is needed...
+    // if (TestNet())
+        // block.nBits = GetNextWorkRequired(pindexPrev, &block);
 }
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -436,20 +436,41 @@ bool CheckWork(CBlock* pblock, CWallet& wallet, CReserveKey& reservekey)
     uint256 hash = pblock->GetPoWHash();
     uint256 hashTarget = CBigNum().SetCompact(pblock->nBits).getuint256();
 
-    if (hash > hashTarget)
-        return false;
-
     //// debug print
-    LogPrintf("AnoncoinMiner:\n");
-    LogPrintf("proof-of-work found  \n  hash: %s  \ntarget: %s\n", hash.GetHex(), hashTarget.GetHex());
-    pblock->print();
-    LogPrintf("generated %s\n", FormatMoney(pblock->vtx[0].vout[0].nValue));
+    LogPrintf("AnoncoinMiner: proof-of-work found.");
+    LogPrintf("\n  hash  : %s\n  target: %s\n", hash.GetHex(), hashTarget.GetHex());
+
+    // This is really a double check on the hash, we would not be here if it had not already been checked, and found to be valid.
+    // The way this is done however, is different, this time we are actually using the block data in a POW recalculation, if any
+    // memory problems had occurred while mining, that might show up here...
+    // Plus its now a way for us to initialize some blocks on TestNet that are fairly evenly spaced in time, before switching on
+    // some new algos or difficulty retargeting systems...
+    if( hash > hashTarget ) {
+        return error( "Unexpected mining check failed, 2nd level proof of work did not confirm block as mined.");
+        // ToDo: May want to raise an assertion here, this should not be happening....
+    }
+
+    // If we are initializing a new blockchain for algo/pow testing, we try to space those initial blocks near our target time span, regardless of mining horse power,
+    // unless it is to small, or the testnet difficulty set to high, then this concept will need to be adjusted...
+    // Note: Don't do this inside of cs_main being locked.
+    if( TestNet() ) {
+        CBlockIndex* pindexPrev = chainActive.Tip();
+        uint64_t nTimeDiff = (uint64_t)(pblock->nTime - pindexPrev->nTime);
+        // For the 1st 22 blocks and if the spacing is less than 90% of the target spacing
+        if( pindexPrev->nHeight <= 22 && nTimeDiff < (nTargetSpacing * 90)/100 ) {
+            LogPrintf( "Initial TestNet block mined %lld seconds to soon, ignored.\n", nTimeDiff );
+            return false;       // So we re-build the block and try again
+        }
+    }
 
     // Found a solution
     {
         LOCK(cs_main);
         if (pblock->hashPrevBlock != chainActive.Tip()->GetBlockHash())
             return error("AnoncoinMiner : generated block is stale");
+
+        pblock->print();
+        LogPrintf("generated %s\n\n", FormatMoney(pblock->vtx[0].vout[0].nValue));
 
         // Remove key from key pool
         reservekey.KeepKey();
@@ -511,12 +532,14 @@ void static AnoncoinMiner(CWallet *pwallet)
 
         FormatHashBuffers(pblock, pmidstate, pdata, phash1);
 
-        unsigned int& nBlockTime = *(unsigned int*)(pdata + 64 + 4);
-        unsigned int& nBlockBits = *(unsigned int*)(pdata + 64 + 8);
+        // unsigned int& nBlockTime = *(unsigned int*)(pdata + 64 + 4);
+        // unsigned int& nBlockBits = *(unsigned int*)(pdata + 64 + 8);
 
         //
         // Search
         //
+        bool fSolutionFound = false;
+        bool fBlockAccepted = false;
         int64_t nStart = GetTime();
         uint256 hashTarget = CBigNum().SetCompact(pblock->nBits).getuint256();
         while (true)
@@ -530,8 +553,9 @@ void static AnoncoinMiner(CWallet *pwallet)
                 if (thash <= hashTarget)
                 {
                     // Found a solution
+                    fSolutionFound = true;
                     SetThreadPriority(THREAD_PRIORITY_NORMAL);
-                    CheckWork(pblock, *pwallet, reservekey);
+                    fBlockAccepted = CheckWork(pblock, *pwallet, reservekey);
                     SetThreadPriority(THREAD_PRIORITY_LOWEST);
 
                     // In regression test mode, stop mining after a block is found. This
@@ -543,6 +567,7 @@ void static AnoncoinMiner(CWallet *pwallet)
                 }
                 pblock->nNonce += 1;
                 nHashesDone += 1;
+                // In this inner loop, we calculate 256 hashes, as fast as can be done, looking for a solution
                 if ((pblock->nNonce & 0xFF) == 0)
                     break;
             }
@@ -586,16 +611,20 @@ void static AnoncoinMiner(CWallet *pwallet)
                 break;
             if (pindexPrev != chainActive.Tip())
                 break;
+            if( fSolutionFound && !fBlockAccepted ) // Something went wrong, so rebuild a new block and try again
+                break;
 
             // Update nTime every few seconds
             UpdateTime(*pblock, pindexPrev);
-            nBlockTime = ByteReverse(pblock->nTime);
-            if (TestNet())
-            {
+            // nBlockTime = ByteReverse(pblock->nTime);  I don't see this being used anywhere
+
+            // ToDo: Why is this needed or used, commenting out until understanding why this must be done here for testnet
+            // if (TestNet())
+            // {
                 // Changing pblock->nTime can change work required on testnet:
-                nBlockBits = ByteReverse(pblock->nBits);
-                hashTarget = CBigNum().SetCompact(pblock->nBits).getuint256();
-            }
+            //    nBlockBits = ByteReverse(pblock->nBits);
+            //    hashTarget = CBigNum().SetCompact(pblock->nBits).getuint256();
+            // }
         }
     } }
     catch (boost::thread_interrupted)

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -501,7 +501,7 @@ void static AnoncoinMiner(CWallet *pwallet)
     unsigned int nExtraNonce = 0;
 
     try { while (true) {
-        if (Params().NetworkID() != CChainParams::REGTEST) {
+        if (BaseParams().NetworkID() != CBaseChainParams::REGTEST) {
             // Busy-wait for the network to come online so we don't waste time mining
             // on an obsolete chain. In regtest mode we expect to fly solo.
             while (vNodes.empty())
@@ -560,7 +560,7 @@ void static AnoncoinMiner(CWallet *pwallet)
 
                     // In regression test mode, stop mining after a block is found. This
                     // allows developers to controllably generate a block on demand.
-                    if (Params().NetworkID() == CChainParams::REGTEST)
+                    if (BaseParams().NetworkID() == CBaseChainParams::REGTEST)
                         throw boost::thread_interrupted();
 
                     break;
@@ -603,7 +603,7 @@ void static AnoncoinMiner(CWallet *pwallet)
 
             // Check for stop or if block needs to be rebuilt
             boost::this_thread::interruption_point();
-            if (vNodes.empty() && Params().NetworkID() != CChainParams::REGTEST)
+            if (vNodes.empty() && BaseParams().NetworkID() != CBaseChainParams::REGTEST)
                 break;
             if (pblock->nNonce >= 0xffff0000)
                 break;
@@ -639,7 +639,7 @@ void GenerateAnoncoins(bool fGenerate, CWallet* pwallet, int nThreads)
     static boost::thread_group* minerThreads = NULL;
 
     if (nThreads < 0) {
-        if (Params().NetworkID() == CChainParams::REGTEST)
+        if (BaseParams().NetworkID() == CBaseChainParams::REGTEST)
             nThreads = 1;
         else
             nThreads = boost::thread::hardware_concurrency();

--- a/src/net.h
+++ b/src/net.h
@@ -452,11 +452,7 @@ public:
         // SendMessages will filter it again for knowns that were added
         // after addresses were pushed.
         if (addr.IsValid() && !setAddrKnown.count(addr))
-            // GR Note: This next commented out line, I think is the cause of allot grief & a coding bug in v0.8.5 and earlier builds
-            // See main.cpp for the fProtocol70007Bug flag and how to solve this abbreviated version message response.
-            // Original comment: if receiver doesn't support i2p-address we don't send it
-            // if ((this->nServices & NODE_I2P) || !addr.IsNativeI2P())
-                vAddrToSend.push_back(addr);
+            vAddrToSend.push_back(addr);
     }
 
 

--- a/src/net.h
+++ b/src/net.h
@@ -113,18 +113,6 @@ bool IsReachable(const CNetAddr &addr);
 void SetReachable(enum Network net, bool fFlag = true);
 CAddress GetLocalAddress(const CNetAddr *paddrPeer = NULL);
 
-/**
- * Specific functions we need to implement I2P functionality
- */
-#ifdef ENABLE_I2PSAM
-std::string FormatI2PNativeFullVersion();
-bool IsDarknetOnly();
-bool IsTorOnly();
-bool IsI2POnly();
-bool IsI2PEnabled();
-bool IsBehindDarknet();
-#endif // ENABLE_I2PSAM
-
 extern bool fDiscover;
 extern uint64_t nLocalServices;
 extern uint64_t nLocalHostNonce;
@@ -312,6 +300,12 @@ public:
       , nRecvStreamType(SER_NETWORK | (((addrIn.nServices & NODE_I2P) || addrIn.IsNativeI2P()) ? 0 : SER_IPADDRONLY))
 #endif
     {
+#ifdef ENABLE_I2PSAM
+        // We don't no the protocol version here yet, nor does the addrIn have it as a member variable anyway
+        // This line of code was left out for 70008, so it doesnt get set until later after the version message
+        // on inbound connections.
+        // if( addrIn->nVersion != 70008 ) ssSend.SetType(nSendStreamType);
+#endif
         nServices = 0;
         hSocket = hSocketIn;
         nRecvVersion = INIT_PROTO_VERSION;
@@ -458,7 +452,11 @@ public:
         // SendMessages will filter it again for knowns that were added
         // after addresses were pushed.
         if (addr.IsValid() && !setAddrKnown.count(addr))
-            vAddrToSend.push_back(addr);
+            // GR Note: This next commented out line, I think is the cause of allot grief & a coding bug in v0.8.5 and earlier builds
+            // See main.cpp for the fProtocol70007Bug flag and how to solve this abbreviated version message response.
+            // Original comment: if receiver doesn't support i2p-address we don't send it
+            // if ((this->nServices & NODE_I2P) || !addr.IsNativeI2P())
+                vAddrToSend.push_back(addr);
     }
 
 

--- a/src/net.h
+++ b/src/net.h
@@ -61,6 +61,7 @@ void AddressCurrentlyConnected(const CService& addr);
 CNode* FindNode(const CNetAddr& ip);
 CNode* FindNode(const CService& ip);
 CNode* ConnectNode(CAddress addrConnect, const char *strDest = NULL);
+bool OpenNetworkConnection(const CAddress& addrConnect, CSemaphoreGrant *grantOutbound = NULL, const char *strDest = NULL, bool fOneShot = false);
 void MapPort(bool fUseUPnP);
 unsigned short GetListenPort();
 bool BindListenPort(const CService &bindAddr, std::string& strError=REF(std::string()));

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -38,8 +38,11 @@ enum Network
     NET_MAX,
 };
 
+class CAddrMan;
+
 extern int nConnectTimeout;
 extern bool fNameLookup;
+extern CAddrMan addrman;
 
 /** IP address (IPv6, or IPv4 using mapped IPv6 range (::FFFF:0:0/96)) */
 class CNetAddr
@@ -86,7 +89,7 @@ class CNetAddr
 #ifdef ENABLE_I2PSAM
         bool IsI2P() const;
         bool IsNativeI2P() const;
-        std::string GetI2PDestination() const;
+        std::string GetI2pDestination() const;
         std::string ToB32String() const;
 #endif
         CNetAddr(const struct in6_addr& pipv6Addr);
@@ -173,6 +176,7 @@ bool LookupNumeric(const char *pszName, CService& addr, int portDefault = 0);
 bool ConnectSocket(const CService &addr, SOCKET& hSocketRet, int nTimeout = nConnectTimeout);
 bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest, int portDefault = 0, int nTimeout = nConnectTimeout);
 bool SetI2pSocketOptions(SOCKET& hSocket);
+void AddTimeData(const CNetAddr& ip, int64_t nTime);
 
 /** Return readable error string for a network error code */
 std::string NetworkErrorString(int err);

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -56,7 +56,7 @@ class CNetAddr
         explicit CNetAddr(const std::string &strIp, bool fAllowLookup = false);
         void Init();
         void SetIP(const CNetAddr& ip);
-        bool SetSpecial(const std::string &strName); // for Tor addresses
+        bool SetSpecial(const std::string &strName); // for Tor & I2P addresses
         bool IsIPv4() const;    // IPv4 mapped address (::FFFF:0:0/96, 0.0.0.0/0)
         bool IsIPv6() const;    // IPv6 address (not mapped IPv4, not Tor)
         bool IsRFC1918() const; // IPv4 private networks (10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12)
@@ -86,6 +86,7 @@ class CNetAddr
 #ifdef ENABLE_I2PSAM
         bool IsNativeI2P() const;
         std::string GetI2PDestination() const;
+        std::string ToB32String() const;
 #endif
         CNetAddr(const struct in6_addr& pipv6Addr);
         bool GetIn6Addr(struct in6_addr* pipv6Addr) const;
@@ -132,9 +133,6 @@ class CService : public CNetAddr
         std::string ToString() const;
         std::string ToStringPort() const;
         std::string ToStringIPPort() const;
-#ifdef ENABLE_I2PSAM
-        std::string ToStringI2pPort() const;
-#endif
         void print() const;
 
         CService(const struct in6_addr& ipv6Addr, unsigned short port);

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -84,6 +84,7 @@ class CNetAddr
         int GetReachabilityFrom(const CNetAddr *paddrPartner = NULL) const;
         void print() const;
 #ifdef ENABLE_I2PSAM
+        bool IsI2P() const;
         bool IsNativeI2P() const;
         std::string GetI2PDestination() const;
         std::string ToB32String() const;
@@ -171,6 +172,8 @@ bool Lookup(const char *pszName, std::vector<CService>& vAddr, int portDefault =
 bool LookupNumeric(const char *pszName, CService& addr, int portDefault = 0);
 bool ConnectSocket(const CService &addr, SOCKET& hSocketRet, int nTimeout = nConnectTimeout);
 bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest, int portDefault = 0, int nTimeout = nConnectTimeout);
+bool SetI2pSocketOptions(SOCKET& hSocket);
+
 /** Return readable error string for a network error code */
 std::string NetworkErrorString(int err);
 #endif

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -76,8 +76,6 @@ bool CMessageHeader::IsValid() const
     return true;
 }
 
-
-
 CAddress::CAddress() : CService()
 {
     Init();

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -87,7 +87,12 @@ enum
 #endif
 };
 
-/** A CService with information about it as peer */
+/** A CService class structure with information about it as a peer... what a mess.
+    The v8 client became split lobed for brains, with one version running on clearnet,
+    and another build type running on I2P.  We need a way to communicate with both,
+    so this class now offers part of the solution as to what serialized address data needs
+    to be read or written to the version running on the other end & attempting to be a peer.
+ */
 class CAddress : public CService
 {
     public:
@@ -104,14 +109,13 @@ class CAddress : public CService
                  pthis->Init();
              if (nType & SER_DISK)
                  READWRITE(nVersion);
-             if ((nType & SER_DISK) ||
-                 (nVersion >= CADDR_TIME_VERSION && !(nType & SER_GETHASH)))
+             if ((nType & SER_DISK) || (nVersion >= CADDR_TIME_VERSION && !(nType & SER_GETHASH)))
                  READWRITE(nTime);
              READWRITE(nServices);
              READWRITE(*pip);
             )
 
-        void print() const;
+        // void print() const; Nobody wrote a routine for this, use CService via inheretance
 
     // TODO: make private (improves encapsulation)
     public:

--- a/src/qt/anoncoin.cpp
+++ b/src/qt/anoncoin.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2011-2014 The Bitcoin developers
-// Copyright (c) 2013-2014 The Anoncoin Core developers
+// Copyright (c) 2013-2015 The Anoncoin Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -608,7 +608,7 @@ int main(int argc, char *argv[])
     if (!PaymentServer::ipcParseCommandLine(argc, argv))
         exit(0);
 #endif
-    bool isaTestNet = Params().NetworkID() != CChainParams::MAIN;
+    bool isaTestNet = BaseParams().NetworkID() != CBaseChainParams::MAIN;
     // Allow for separate UI settings for testnets
     if (isaTestNet)
         QApplication::setApplicationName(QAPP_APP_NAME_TESTNET);

--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -51,7 +51,7 @@
       <item>
        <widget class="QValidatedLineEdit" name="payTo">
         <property name="toolTip">
-         <string>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</string>
+         <string>The address to send the payment to (e.g. AZhGrZf4UcNGQ1spYXKrrKeksvei9FGfyk)</string>
         </property>
        </widget>
       </item>

--- a/src/qt/forms/signverifymessagedialog.ui
+++ b/src/qt/forms/signverifymessagedialog.ui
@@ -45,7 +45,7 @@
          <item>
           <widget class="QValidatedLineEdit" name="addressIn_SM">
            <property name="toolTip">
-            <string>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</string>
+            <string>The address to sign the message with (e.g. AZhGrZf4UcNGQ1spYXKrrKeksvei9FGfyk)</string>
            </property>
           </widget>
          </item>
@@ -255,7 +255,7 @@
          <item>
           <widget class="QValidatedLineEdit" name="addressIn_VM">
            <property name="toolTip">
-            <string>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</string>
+            <string>The address the message was signed with (e.g. AZhGrZf4UcNGQ1spYXKrrKeksvei9FGfyk)</string>
            </property>
           </widget>
          </item>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -99,7 +99,7 @@ void setupAddressWidget(QValidatedLineEdit *widget, QWidget *parent)
 
     widget->setFont(anoncoinAddressFont());
 #if QT_VERSION >= 0x040700
-    widget->setPlaceholderText(QObject::tr("Enter a Anoncoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)"));
+    widget->setPlaceholderText(QObject::tr("Enter a Anoncoin address (e.g. AZhGrZf4UcNGQ1spYXKrrKeksvei9FGfyk)"));
 #endif
     widget->setValidator(new AnoncoinAddressEntryValidator(parent));
     widget->setCheckValidator(new AnoncoinAddressCheckValidator(parent));
@@ -827,21 +827,23 @@ QString formatServicesStr(quint64 mask)
 {
     QStringList strList;
 
-    // Just scan the last 8 bits for now.
-    for (int i = 0; i < 8; i++) {
+    // Scan 32 bits, tried 64 but that caused double entries to appear in the peertable
+    // ToDo: figure out why that didn't work as I thought the service
+    // bits was 64 bits wide....perhaps not.
+    for (int i = 0; i < 32; i++) {
         uint64_t check = 1 << i;
         if (mask & check)
         {
             switch (check)
             {
             case NODE_NETWORK:
-                strList.append(QObject::tr("CLEARNET"));
+                strList.append(QObject::tr("FULL_BLOCKS"));
                 break;
             case NODE_BLOOM:
-                strList.append(QObject::tr("BLOOM"));
+                strList.append(QObject::tr("BLOOM_FILTER"));
                 break;
             case NODE_I2P:
-                strList.append(QObject::tr("I2PNET"));
+                strList.append(QObject::tr("I2P_ROUTER"));
                 break;
             default:
                 strList.append(QString("%1[%2]").arg(QObject::tr("UNKNOWN")).arg(check));

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2011-2013 The Bitcoin developers
-// Copyright (c) 2013-2014 The Anoncoin Core developers
+// Copyright (c) 2013-2015 The Anoncoin Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -196,10 +196,10 @@ bool PaymentServer::ipcParseCommandLine(int argc, char* argv[])
             {
                 CAnoncoinAddress address(r.address.toStdString());
 
-                SelectParams(CChainParams::MAIN);
+                SelectParams(CBaseChainParams::MAIN);
                 if (!address.IsValid())
                 {
-                    SelectParams(CChainParams::TESTNET);
+                    SelectParams(CBaseChainParams::TESTNET);
                 }
             }
         }
@@ -211,9 +211,9 @@ bool PaymentServer::ipcParseCommandLine(int argc, char* argv[])
             if (readPaymentRequest(arg, request))
             {
                 if (request.getDetails().network() == "main")
-                    SelectParams(CChainParams::MAIN);
+                    SelectParams(CBaseChainParams::MAIN);
                 else
-                    SelectParams(CChainParams::TESTNET);
+                    SelectParams(CBaseChainParams::TESTNET);
             }
         }
         else

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -29,7 +29,7 @@ SignVerifyMessageDialog::SignVerifyMessageDialog(QWidget *parent) :
 #if QT_VERSION >= 0x040700
     ui->signatureOut_SM->setPlaceholderText(tr("Click \"Sign Message\" to generate signature"));
     // ToDo: ...make the e.g. look right
-    ui->addressIn_VM->setPlaceholderText(tr("Enter an Anoncoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)"));
+    ui->addressIn_VM->setPlaceholderText(tr("Enter an Anoncoin address (e.g. AZhGrZf4UcNGQ1spYXKrrKeksvei9FGfyk)"));
 #endif
 
     GUIUtil::setupAddressWidget(ui->addressIn_SM, this);

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -32,8 +32,7 @@ AboutDialog::AboutDialog(QWidget *parent) :
     // Set current copyright year for all the crypos we're involved in mining and algos from...
     ui->copyrightLabel->setText(tr("Copyright") + QString(" &copy; 2013-%1 ").arg(COPYRIGHT_YEAR) + tr("The Anoncoin Core developers")
         + QString("<br>") + tr("Copyright") + QString(" &copy; 2009-%1 ").arg(2015) + tr("The Bitcoin Core developers")
-        + QString("<br>") + tr("Copyright") + QString(" &copy; 2011-%1 ").arg(2014) + tr("The Litecoin Core developers")
-        + QString("<br>") + tr("Copyright") + QString(" &copy; 2013 ") + tr("The Primecoin developers"));
+        + QString("<br>") + tr("Copyright") + QString(" &copy; 2011-%1 ").arg(2014) + tr("The Litecoin Core developers") );
 }
 
 void AboutDialog::setModel(ClientModel *model)

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -18,38 +18,6 @@ using namespace std;
 
 void ScriptPubKeyToJSON(const CScript& scriptPubKey, Object& out, bool fIncludeHex);
 
-double GetDifficulty(const CBlockIndex* blockindex)
-{
-    // Floating point number that is a multiple of the minimum difficulty,
-    // minimum difficulty = 1.0.
-    if (blockindex == NULL)
-    {
-        if (chainActive.Tip() == NULL)
-            return 1.0;
-        else
-            blockindex = chainActive.Tip();
-    }
-
-    int nShift = (blockindex->nBits >> 24) & 0xff;
-
-    double dDiff =
-        (double)0x0000ffff / (double)(blockindex->nBits & 0x00ffffff);
-
-    while (nShift < 29)
-    {
-        dDiff *= 256.0;
-        nShift++;
-    }
-    while (nShift > 29)
-    {
-        dDiff /= 256.0;
-        nShift--;
-    }
-
-    return dDiff;
-}
-
-
 Object blockToJSON(const CBlock& block, const CBlockIndex* blockindex)
 {
     Object result;

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -10,7 +10,7 @@
 #include "rpcprotocol.h"
 #include "util.h"
 #include "ui_interface.h"
-#include "chainparams.h" // for Params().RPCPort()
+#include "chainparamsbase.h" // for Params().RPCPort()
 
 #include <stdint.h>
 
@@ -49,7 +49,7 @@ Object CallRPC(const string& strMethod, const Array& params)
 
     bool fWait = GetBoolArg("-rpcwait", false); // -rpcwait means try until server has started
     do {
-        bool fConnected = d.connect(GetArg("-rpcconnect", "127.0.0.1"), GetArg("-rpcport", itostr(Params().RPCPort())));
+        bool fConnected = d.connect(GetArg("-rpcconnect", "127.0.0.1"), GetArg("-rpcport", itostr(BaseParams().RPCPort())));
         if (fConnected) break;
         if (fWait)
             MilliSleep(1000);

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -162,6 +162,15 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "verifychain", 1 },
     { "keypoolrefill", 0 },
     { "getrawmempool", 0 },
+#if CLIENT_VERSION_IS_RELEASE != true
+    { "sendalert", 2 },
+    { "sendalert", 3 },
+    { "sendalert", 5 },
+    { "sendalert", 6 },
+    { "sendalert", 7 },
+    { "sendalert", 8 },
+    { "sendalert", 9 },
+#endif
 };
 
 class CRPCConvertTable
@@ -298,7 +307,7 @@ std::string HelpMessageCli(bool mainProgram)
     }
 
     strUsage += "  -rpcconnect=<ip>       " + _("Send commands to node running on <ip> (default: 127.0.0.1)") + "\n";
-    strUsage += "  -rpcport=<port>        " + _("Connect to JSON-RPC on <port> (default: 9332 or testnet: 19332)") + "\n";
+    strUsage += "  -rpcport=<port>        " + _("Connect to JSON-RPC on <port> (default: 9376 or testnet: 19376)") + "\n";
     strUsage += "  -rpcwait               " + _("Wait for RPC server to start") + "\n";
 
     if(mainProgram)

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2009-2013 The Bitcoin developers
-// Copyright (c) 2013-2014 The Anoncoin Core developers
+// Copyright (c) 2013-2015 The Anoncoin Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -181,7 +181,7 @@ Value setgenerate(const Array& params, bool fHelp)
     }
 
     // -regtest mode: don't return until nGenProcLimit blocks are generated
-    if (fGenerate && Params().NetworkID() == CChainParams::REGTEST)
+    if (fGenerate && BaseParams().NetworkID() == CBaseChainParams::REGTEST)
     {
         int nHeightStart = 0;
         int nHeightEnd = 0;

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -60,6 +60,7 @@ void ShutdownRPCMining()
 // Return average network hashes per second based on the last 'lookup' blocks,
 // or from the last difficulty change if 'lookup' is nonpositive.
 // If 'height' is nonnegative, compute the estimate at the time when a given block was found.
+// ToDo: This needs to be redone for Anoncoin
 Value GetNetworkHashPS(int lookup, int height) {
     CBlockIndex *pb = chainActive.Tip();
 

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -169,7 +169,11 @@ Value addnode(const Array& params, bool fHelp)
     if (strCommand == "onetry")
     {
         CAddress addr;
-        ConnectNode(addr, strNode.c_str());
+        // The Oneshot flag 'could' be true here...
+        // If it is true, then the node if connects, will be queried for addresses
+        // and disconnected, so for this command we call it set false, as we want
+        // stay connected if we can.
+        OpenNetworkConnection(addr, NULL, strNode.c_str(), false);
         return Value::null;
     }
 

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -11,13 +11,11 @@
 #include "protocol.h"
 #include "sync.h"
 #include "util.h"
-#include "version.h"
+#include "alert.h"
+#include "base58.h"
 
 #include <boost/foreach.hpp>
 #include "json/json_spirit_value.h"
-/* #include "anoncoinrpc.h" */
-#include "alert.h"
-#include "base58.h"
 
 using namespace json_spirit;
 using namespace std;
@@ -93,8 +91,8 @@ Value getpeerinfo(const Array& params, bool fHelp)
             "    \"conntime\": ttt,           (numeric) The connection time in seconds since epoch (Jan 1 1970 GMT)\n"
             "    \"pingtime\": n,             (numeric) ping time\n"
             "    \"pingwait\": n,             (numeric) ping wait\n"
-            "    \"version\": v,              (numeric) The peer version, such as 7001\n"
-            "    \"subver\": \"/Satoshi:0.8.5/\",  (string) The string version\n"
+            "    \"version\": v,              (numeric) The peer version, such as 70008\n"
+            "    \"subver\": \"/s:n.n.n.n/\", (string) The subversion string\n"
             "    \"inbound\": true|false,     (boolean) Inbound (true) or Outbound (false)\n"
             "    \"startingheight\": n,       (numeric) The starting height (block) of the peer\n"
             "    \"banscore\": n,             (numeric) The ban score\n"
@@ -162,8 +160,8 @@ Value addnode(const Array& params, bool fHelp)
             "1. \"node\"     (string, required) The node (see getpeerinfo for nodes)\n"
             "2. \"command\"  (string, required) 'add' to add a node to the list, 'remove' to remove a node from the list, 'onetry' to try a connection to the node once\n"
             "\nExamples:\n"
-            + HelpExampleCli("addnode", "\"192.168.0.6:9333\" \"onetry\"")
-            + HelpExampleRpc("addnode", "\"192.168.0.6:9333\", \"onetry\"")
+            + HelpExampleCli("addnode", "\"192.168.0.6:9377\" \"onetry\"")
+            + HelpExampleRpc("addnode", "\"192.168.0.6:9377\", \"onetry\"")
         );
 
     string strNode = params[0].get_str();
@@ -216,7 +214,7 @@ Value getaddednodeinfo(const Array& params, bool fHelp)
             "    \"connected\" : true|false,          (boolean) If connected\n"
             "    \"addresses\" : [\n"
             "       {\n"
-            "         \"address\" : \"192.168.0.201:9333\",  (string) The anoncoin server host and port\n"
+            "         \"address\" : \"192.168.0.201:9377\",  (string) The anoncoin server host and port\n"
             "         \"connected\" : \"outbound\"           (string) connection, inbound or outbound\n"
             "       }\n"
             "       ,...\n"
@@ -359,6 +357,17 @@ static Array GetNetworksInfo()
     return networks;
 }
 
+static const string SingleAlertSubVersionsString( const std::set<std::string>& setVersions )
+{
+    std::string strSetSubVer;
+    BOOST_FOREACH(std::string str, setVersions) {
+        if(strSetSubVer.size())                 // Must be more than one
+            strSetSubVer += " or ";
+        strSetSubVer += str;
+    }
+    return strSetSubVer;
+}
+
 Value getnetworkinfo(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
@@ -368,22 +377,32 @@ Value getnetworkinfo(const Array& params, bool fHelp)
             "\nResult:\n"
             "{\n"
             "  \"version\": xxxxx,           (numeric) the server version\n"
+            "  \"subver\": \"/s:n.n.n.n/\",  (string)  this clients subversion string\n"
             "  \"protocolversion\": xxxxx,   (numeric) the protocol version\n"
-            "  \"localservices\": \"xxxxxxxxxxxxxxxx\",   (string) the services we offer to the network\n"
+            "  \"localservices\": xxxxxxxx,  (numeric) in Hex, the local service bits\n"
             "  \"timeoffset\": xxxxx,        (numeric) the time offset\n"
             "  \"connections\": xxxxx,       (numeric) the number of connections\n"
-            "  \"networks\": [               (array) information per network\n"
-            "      \"name\": \"xxx\",        (string) network (ipv4, ipv6 or onion)\n"
-            "      \"limited\": xxx,         (boolean) is the network limited using -onlynet?\n"
-            "      \"reachable\": xxx,       (boolean) is the network reachable?\n"
-            "      \"proxy\": \"host:port\"  (string) the proxy that is used for this network, or empty if none\n"
-            "    },\n"
-            "  ],\n"
-            "  \"relayfee\": x.xxxx,         (numeric) minimum relay fee for non-free transactions in btc/kb\n"
+            "  \"relayfee\": x.xxxx,         (numeric) minimum relay fee for non-free transactions in ixc/kb\n"
+            "  \"networkconnections\": [,    (array)  the state of each possible network connection type\n"
+            "    \"name\": \"xxx\",          (string) network name\n"
+            "    \"limited\" : true|false,   (boolean) if service is limited\n"
+            "    \"reachable\" : true|false, (boolean) if service is reachable\n"
+            "    \"proxy\": \"host:port\",   (string, optional) the proxy used by the server\n"
+            "  ]\n"
             "  \"localaddresses\": [,        (array) list of local addresses\n"
             "    \"address\": \"xxxx\",      (string) network address\n"
             "    \"port\": xxx,              (numeric) network port\n"
             "    \"score\": xxx              (numeric) relative score\n"
+            "  ]\n"
+            "  \"alerts\": [,                (array) list of alerts on network\n"
+            "    \"alertid\": \"xxx\",       (numeric) the ID number for this alert\n"
+            "    \"priority\": xxx,          (numeric) the alert priority\n"
+            "    \"minver\": xxx             (numeric) the minimum protocol version this effects\n"
+            "    \"maxver\": xxx             (numeric) the maximum protocol version this effects\n"
+            "    \"subvers\": \"/s:n.n.n.n/\",(string) null=all or the client version(s) this effects\n"
+            "    \"relayuntil\": xxx         (numeric) relay this alert to other nodes until this time\n"
+            "    \"expiration\": xxx         (numeric) when this alert will expire\n"
+            "    \"statusbar\": \"xxxx\",    (string) status bar & tooltip string displayed\n"
             "  ]\n"
             "}\n"
             "\nExamples:\n"
@@ -392,15 +411,14 @@ Value getnetworkinfo(const Array& params, bool fHelp)
         );
 
     Object obj;
-    obj.push_back(Pair("version",       (int)CLIENT_VERSION));
-    obj.push_back(Pair("subversion",
-        FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, std::vector<string>())));
+    obj.push_back(Pair("version",        (int)CLIENT_VERSION));
+    obj.push_back(Pair("subversion",     FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, std::vector<string>())));
     obj.push_back(Pair("protocolversion",(int)PROTOCOL_VERSION));
-    obj.push_back(Pair("localservices",       strprintf("%016x", nLocalServices)));
-    obj.push_back(Pair("timeoffset",    GetTimeOffset()));
-    obj.push_back(Pair("connections",   (int)vNodes.size()));
-    obj.push_back(Pair("networks",      GetNetworksInfo()));
-    obj.push_back(Pair("relayfee",      ValueFromAmount(CTransaction::nMinRelayTxFee)));
+    obj.push_back(Pair("localservices",  strprintf("%08x", nLocalServices)));
+    obj.push_back(Pair("timeoffset",     GetTimeOffset()));
+    obj.push_back(Pair("connections",    (int)vNodes.size()));
+    obj.push_back(Pair("relayfee",       ValueFromAmount(CTransaction::nMinRelayTxFee)));
+    obj.push_back(Pair("networkconnections",GetNetworksInfo()));
     Array localAddresses;
     {
         LOCK(cs_mapLocalHost);
@@ -414,7 +432,164 @@ Value getnetworkinfo(const Array& params, bool fHelp)
         }
     }
     obj.push_back(Pair("localaddresses", localAddresses));
+
+    // Add in the list of alerts currently on the network
+    Array localAlerts;
+    if( !mapAlerts.empty() ) {
+          // Parse all the alerts, and prepare a JSON response list
+          LOCK(cs_mapAlerts);
+          for( map<uint256, CAlert>::iterator mi = mapAlerts.begin(); mi != mapAlerts.end(); mi++ ) {
+               const CAlert& alert = (*mi).second;
+               Object rec;
+               rec.push_back( Pair("AlertID", alert.nID) );
+               rec.push_back( Pair("Priority", alert.nPriority) );
+               rec.push_back( Pair("MinVer", alert.nMinVer) );
+               rec.push_back( Pair("MaxVer", alert.nMaxVer) );
+               rec.push_back( Pair("SubVer", SingleAlertSubVersionsString(alert.setSubVer)) );
+               rec.push_back( Pair("RelayUntil", alert.nRelayUntil) );
+               rec.push_back( Pair("Expiration", alert.nExpiration) );
+               rec.push_back( Pair("StatusBar", alert.strStatusBar) );
+               localAlerts.push_back(rec);
+          }
+    }
+    obj.push_back(Pair("alerts", localAlerts));
+
     return obj;
+}
+
+// Only build this code in preleases or test builds
+#if CLIENT_VERSION_IS_RELEASE != true
+//
+// This allows our developers to notify all nodes of any issues on the Anoncoin network
+//
+Value sendalert(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() < 7)
+        throw runtime_error(
+            "sendalert <message> <privatekey> <minver> <maxver> <subvers> <priority> <id> [relaydays] [expiredays] [cancelupto]\n"
+            "<message> is the alert text message\n"
+            "<privatekey> is hex string of alert private key\n"
+            "<minver> is the minimum applicable protocol version\n"
+            "<maxver> is the maximum applicable protocol version\n"
+            "<subvers> if not null, a specific set of client version(s) (see BIP14 for specs)\n"
+            "<priority> is integer priority number\n"
+            "<id> is the alert id you have assigned\n"
+            "[relaydays]  relay this alert for this many days\n"
+            "[expiredays] expire this alert in this many days\n"
+            "[cancelupto] cancels all alert id's up to this number\n"
+            "Returns JSON result if successful.");
+
+    CAlert alert;
+    CKey key;
+
+    alert.strStatusBar = params[0].get_str();
+    alert.nMinVer = params[2].get_int();
+    alert.nMaxVer = params[3].get_int();
+
+    // We need to parse out the subversion strings as per BIP14 and create a
+    // set of matchable versions this alert is targeted for.  A null string
+    // indicates all version, 1st we do a small bit of user input verification.
+    // So this should work if the string is null, if there is one version string,
+    // or more, separated by '/' as per the specification.
+    string strSetSubVers = params[4].get_str();
+    if( strSetSubVers.size() ) {
+        // The 1st and last chars need to be a '/' or it was not entered correctly
+        if( strSetSubVers[0] == '/'  && strSetSubVers[ strSetSubVers.size() - 1 ] == '/' ) {
+            std::string::size_type iPos = 1, iLast;     // We have at least one likely good string
+            while( ( iLast = strSetSubVers.find('/',iPos--) ) != std::string::npos ) {
+                alert.setSubVer.insert( strSetSubVers.substr(iPos,++iLast-iPos));
+                iPos = iLast;
+            }
+        } else
+            throw runtime_error( "Invalid client subversion(s) string, see BIP14 for specifications\n");
+    }
+    // else We're done, the set of subver strings defaults to null on creation.
+    alert.nPriority = params[5].get_int();
+    alert.nID = params[6].get_int();
+    if (params.size() > 9)
+        alert.nCancel = params[9].get_int();
+    alert.nVersion = PROTOCOL_VERSION;
+
+    // Relay and don't expire this alert for one year, or the number of days given
+    const int64_t i64AlertNow = GetAdjustedTime();
+
+    alert.nRelayUntil = ( params.size() > 7 ) ? params[7].get_int() : 365;
+    alert.nRelayUntil *= 24*60*60;       // One day in seconds
+    alert.nRelayUntil += i64AlertNow;
+
+    alert.nExpiration = ( params.size() > 8 ) ? params[8].get_int() : 365;
+    alert.nExpiration *= 24*60*60;       // One day in seconds
+    alert.nExpiration += i64AlertNow;
+
+    CDataStream sMsg(SER_NETWORK, PROTOCOL_VERSION);
+    sMsg << (CUnsignedAlert)alert;
+    alert.vchMsg = vector<unsigned char>(sMsg.begin(), sMsg.end());
+
+    // From https://bitcointalk.org/index.php?topic=50330.40:
+    //
+    // CKey::GetPrivKey and CKey::SetPrivKey are accessor methods for the 279-byte DES private key.
+    // CKey::GetSecret and CKey::SetSecret are accessor methods for the 32-byte private key.
+    //
+    // Those of you who are interested in the OpenSSL calls needed, it's all spelled out in key.h
+    //
+    //  If the SendAlert user is giving us the 32 byte secret code & we already know the public key, so...
+    //  Setup an object with the correct value for the private key, otherwise we'll assume they are giving us the
+    //  private key as the string value, and use that to create the key object.
+    //  Either of the above must be given, before this code can sign and then process the alert.
+    //
+    // There are various code fragments below that are commented out for release builds. Helpful however, for debugging
+    // changes to the code and/or keys being used.  Otherwise not needed
+    //
+    //  Move the SendAlert 2nd parmeter chars into a vector, whichever it is, can assume it's being given to us as hex pairs
+    vector<unsigned char> vchPrivKey = ParseHex(params[1].get_str());
+
+    if( vchPrivKey.size() == 32 ) {         // Then we're given only a 32-byte private key multipler
+        key.Set( vchPrivKey.begin(), vchPrivKey.end(), false );
+        CPrivKey nPK = key.GetPrivKey();    // This calls openssl & sets the key structure up correctly.
+        // Print out the private key here, from being set by SecretBytes...
+        std::string strKey;
+        for( size_t i=0; i<nPK.size(); i++ )
+            strKey += strprintf( "%02x", nPK[i] );
+        LogPrintf("SendAlert pass is the SecretBytes, Private Key Value is:\n%s\n", strKey);
+    }
+    else if( !key.SetPrivKey( CPrivKey(vchPrivKey.begin(), vchPrivKey.end()), false ) )
+        throw runtime_error( "Unable to verify alert Private key, check private key?\n");
+    else
+        LogPrintf("SendAlert pass is the PrivateKey.\n");
+
+    // Sign the message & set the alert vchSig string...
+    if (!key.Sign(Hash(alert.vchMsg.begin(), alert.vchMsg.end()), alert.vchSig))
+        throw runtime_error( "Unable to sign alert, check private key?\n");
+    else if(!alert.ProcessAlert())
+        throw runtime_error( "Failed to process alert.\n");
+    //
+    // If you need to, Print out the CAlert structure, into the log file here:
+    alert.print();
+    //
+    // After we've called alert.ProcessAlert(), the public key will have been used to verify the
+    // signature of the (now) signed alert message, or a runtime_error would have been returned.
+
+    // Relay alert to the other nodes
+    {
+        LOCK(cs_vNodes);
+        BOOST_FOREACH(CNode* pnode, vNodes)
+            alert.RelayTo(pnode);
+    }
+    // At this point, the Anoncoin network will be flooded with the alert message before very much time has passed.
+
+    Object res;
+    res.push_back( Pair("AlertID", alert.nID) );
+    res.push_back( Pair("Priority", alert.nPriority) );
+    res.push_back( Pair("Version", alert.nVersion) );
+    res.push_back( Pair("MinVer", alert.nMinVer) );
+    res.push_back( Pair("MaxVer", alert.nMaxVer) );
+    res.push_back( Pair("SubVer", SingleAlertSubVersionsString(alert.setSubVer)) );
+    res.push_back( Pair("RelayUntil", alert.nRelayUntil) );
+    res.push_back( Pair("Expiration", alert.nExpiration) );
+    res.push_back( Pair("StatusBar", alert.strStatusBar) );
+    if (alert.nCancel > 0)
+        res.push_back( Pair("Cancel", alert.nCancel) );
+    return res;
 }
 
 Value makekeypair(const Array& params, bool fHelp)
@@ -447,3 +622,5 @@ Value makekeypair(const Array& params, bool fHelp)
     result.push_back(Pair("PrivateKey", CAnoncoinSecret(key).ToString()));
     return result;
 }
+
+#endif  // !CLIENT_VERSION_IS_RELEASE

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -171,21 +171,26 @@ string CRPCTable::help(string strCommand) const
             continue;
 #endif
 
-        try
+#if CLIENT_VERSION_IS_RELEASE != true
+        if( strMethod != "makekeypair" && strMethod != "sendalert" )
+#endif
         {
-            Array params;
-            rpcfn_type pfn = pcmd->actor;
-            if (setDone.insert(pfn).second)
-                (*pfn)(params, true);
-        }
-        catch (std::exception& e)
-        {
-            // Help text is returned in an exception
-            string strHelp = string(e.what());
-            if (strCommand == "")
-                if (strHelp.find('\n') != string::npos)
-                    strHelp = strHelp.substr(0, strHelp.find('\n'));
-            strRet += strHelp + "\n";
+            try
+            {
+                Array params;
+                rpcfn_type pfn = pcmd->actor;
+                if (setDone.insert(pfn).second)
+                    (*pfn)(params, true);
+            }
+            catch (std::exception& e)
+            {
+                // Help text is returned in an exception
+                string strHelp = string(e.what());
+                if (strCommand == "")
+                    if (strHelp.find('\n') != string::npos)
+                        strHelp = strHelp.substr(0, strHelp.find('\n'));
+                strRet += strHelp + "\n";
+            }
         }
     }
     if (strRet == "")
@@ -281,6 +286,11 @@ static const CRPCCommand vRPCCommands[] =
     { "validateaddress",        &validateaddress,        true,      false,      false }, /* uses wallet if enabled */
     { "verifymessage",          &verifymessage,          false,     false,      false },
 
+#if CLIENT_VERSION_IS_RELEASE != true
+    { "makekeypair",            &makekeypair,            true,     	false,		false },
+    { "sendalert",              &sendalert,              false,     false,      false },
+#endif
+
 #ifdef ENABLE_WALLET
     /* Wallet */
     { "addmultisigaddress",     &addmultisigaddress,     false,     false,      true },
@@ -310,8 +320,6 @@ static const CRPCCommand vRPCCommands[] =
     { "listreceivedbyaddress",  &listreceivedbyaddress,  false,     false,      true },
     { "listsinceblock",         &listsinceblock,         false,     false,      true },
     { "listtransactions",       &listtransactions,       false,     false,      true },
-    { "makekeypair",            &makekeypair,            true,     	false,		true },
-    { "dumpprivkey",            &dumpprivkey,            true,      false,      true },
     { "listunspent",            &listunspent,            false,     false,      true },
     { "lockunspent",            &lockunspent,            false,     false,      true },
     { "move",                   &movecmd,                false,     false,      true },
@@ -909,7 +917,7 @@ std::string HelpExampleCli(string methodname, string args){
 
 std::string HelpExampleRpc(string methodname, string args){
     return "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", "
-        "\"method\": \"" + methodname + "\", \"params\": [" + args + "] }' -H 'content-type: text/plain;' http://127.0.0.1:9332/\n";
+        "\"method\": \"" + methodname + "\", \"params\": [" + args + "] }' -H 'content-type: text/plain;' http://127.0.0.1:9376/\n";
 }
 
 const CRPCTable tableRPC;

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -582,7 +582,7 @@ void StartRPCThreads()
     // Try a dual IPv6/IPv4 socket, falling back to separate IPv4 and IPv6 sockets
     const bool loopback = !mapArgs.count("-rpcallowip");
     asio::ip::address bindAddress = loopback ? asio::ip::address_v6::loopback() : asio::ip::address_v6::any();
-    ip::tcp::endpoint endpoint(bindAddress, GetArg("-rpcport", Params().RPCPort()));
+    ip::tcp::endpoint endpoint(bindAddress, GetArg("-rpcport", BaseParams().RPCPort()));
     boost::system::error_code v6_only_error;
 
     bool fListening = false;

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -1,9 +1,8 @@
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin developers
-// Copyright (c) 2013-2014 The Anoncoin Core developers
+// Copyright (c) 2013-2015 The Anoncoin Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
 #ifndef _ANONCOINRPC_SERVER_H_
 #define _ANONCOINRPC_SERVER_H_
 
@@ -156,7 +155,6 @@ extern json_spirit::Value listtransactions(const json_spirit::Array& params, boo
 extern json_spirit::Value listaddressgroupings(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value listaccounts(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value listsinceblock(const json_spirit::Array& params, bool fHelp);
-extern json_spirit::Value makekeypair(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value gettransaction(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value backupwallet(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value keypoolrefill(const json_spirit::Array& params, bool fHelp);
@@ -190,5 +188,8 @@ extern json_spirit::Value getblock(const json_spirit::Array& params, bool fHelp)
 extern json_spirit::Value gettxoutsetinfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value gettxout(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value verifychain(const json_spirit::Array& params, bool fHelp);
+// These are only included in pre-release builds
+extern json_spirit::Value sendalert(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value makekeypair(const json_spirit::Array& params, bool fHelp);
 
-#endif
+#endif // header guard

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -101,7 +101,6 @@ extern void ShutdownRPCMining();
 extern int64_t nWalletUnlockTime;
 extern int64_t AmountFromValue(const json_spirit::Value& value);
 extern json_spirit::Value ValueFromAmount(int64_t amount);
-extern double GetDifficulty(const CBlockIndex* blockindex = NULL);
 extern std::string HexBits(unsigned int nBits);
 extern std::string HelpRequiringPassphrase();
 extern std::string HelpExampleCli(std::string methodname, std::string args);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1219,6 +1219,8 @@ void ShrinkDebugFile()
 //  - Median of other nodes clocks
 //  - The user (asking the user to fix the system clock if the first two disagree)
 //
+// ToDo: GrNotes: Anoncoin may have other options to explore, as in I2P related queries, or ntp servers, why are they not looked at, needs investigation
+// We do not yet have a unit test network, v10 does and this aspect is now at least partially done...
 static int64_t nMockTime = 0;  // For unit testing
 
 int64_t GetTime()

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6,9 +6,8 @@
 
 #include "util.h"
 
-#include "chainparams.h"
+#include "chainparamsbase.h"
 #include "netbase.h"
-#include "sync.h"
 #include "ui_interface.h"
 #include "uint256.h"
 #include "version.h"
@@ -273,7 +272,7 @@ int LogPrintStr(const std::string &str)
         // print to console
         ret = fwrite(str.data(), 1, str.size(), stdout);
     }
-    else if (fPrintToDebugLog)
+    else if (fPrintToDebugLog && AreBaseParamsConfigured())
     {
         static bool fStartedNewLine = true;
         boost::call_once(&DebugPrintInit, debugPrintInitFlag);
@@ -962,7 +961,7 @@ boost::filesystem::path GetDefaultDataDir()
 #endif // WIN32
 }
 
-static boost::filesystem::path pathCached[CChainParams::MAX_NETWORK_TYPES+1];
+static boost::filesystem::path pathCached[CBaseChainParams::MAX_NETWORK_TYPES+1];
 static CCriticalSection csPathCached;
 
 const boost::filesystem::path &GetDataDir(bool fNetSpecific)
@@ -971,8 +970,8 @@ const boost::filesystem::path &GetDataDir(bool fNetSpecific)
 
     LOCK(csPathCached);
 
-    int nNet = CChainParams::MAX_NETWORK_TYPES;
-    if (fNetSpecific) nNet = Params().NetworkID();
+    int nNet = CBaseChainParams::MAX_NETWORK_TYPES;
+    if (fNetSpecific) nNet = BaseParams().NetworkID();
 
     fs::path &path = pathCached[nNet];
 
@@ -991,7 +990,7 @@ const boost::filesystem::path &GetDataDir(bool fNetSpecific)
         path = GetDefaultDataDir();
     }
     if (fNetSpecific)
-        path /= Params().DataDir();
+        path /= BaseParams().DataDir();
 
     fs::create_directories(path);
 
@@ -1000,7 +999,7 @@ const boost::filesystem::path &GetDataDir(bool fNetSpecific)
 
 void ClearDatadirCache()
 {
-    std::fill(&pathCached[0], &pathCached[CChainParams::MAX_NETWORK_TYPES+1],
+    std::fill(&pathCached[0], &pathCached[CBaseChainParams::MAX_NETWORK_TYPES+1],
               boost::filesystem::path());
 }
 
@@ -1235,8 +1234,8 @@ void SetMockTime(int64_t nMockTimeIn)
     nMockTime = nMockTimeIn;
 }
 
-static CCriticalSection cs_nTimeOffset;
-static int64_t nTimeOffset = 0;
+CCriticalSection cs_nTimeOffset;
+int64_t nTimeOffset = 0;
 
 int64_t GetTimeOffset()
 {
@@ -1247,61 +1246,6 @@ int64_t GetTimeOffset()
 int64_t GetAdjustedTime()
 {
     return GetTime() + GetTimeOffset();
-}
-
-void AddTimeData(const CNetAddr& ip, int64_t nTime)
-{
-    int64_t nOffsetSample = nTime - GetTime();
-
-    LOCK(cs_nTimeOffset);
-    // Ignore duplicates
-    static set<CNetAddr> setKnown;
-    if (!setKnown.insert(ip).second)
-        return;
-
-    // Add data
-    static CMedianFilter<int64_t> vTimeOffsets(200,0);
-    vTimeOffsets.input(nOffsetSample);
-    LogPrintf("Added time data, samples %d, offset %+d (%+d minutes)\n", vTimeOffsets.size(), nOffsetSample, nOffsetSample/60);
-    if (vTimeOffsets.size() >= 5 && vTimeOffsets.size() % 2 == 1)
-    {
-        int64_t nMedian = vTimeOffsets.median();
-        std::vector<int64_t> vSorted = vTimeOffsets.sorted();
-        // Only let other nodes change our time by so much
-        if (abs64(nMedian) < 35 * 60)
-        {
-            nTimeOffset = nMedian;
-        }
-        else
-        {
-            nTimeOffset = 0;
-
-            static bool fDone;
-            if (!fDone)
-            {
-                // If nobody has a time different than ours but within 5 minutes of ours, give a warning
-                bool fMatch = false;
-                BOOST_FOREACH(int64_t nOffset, vSorted)
-                    if (nOffset != 0 && abs64(nOffset) < 5 * 60)
-                        fMatch = true;
-
-                if (!fMatch)
-                {
-                    fDone = true;
-                    string strMessage = _("Warning: Please check that your computer's date and time are correct! If your clock is wrong Anoncoin will not work properly.");
-                    strMiscWarning = strMessage;
-                    LogPrintf("*** %s\n", strMessage);
-                    uiInterface.ThreadSafeMessageBox(strMessage, "", CClientUIInterface::MSG_WARNING);
-                }
-            }
-        }
-        if (fDebug) {
-            BOOST_FOREACH(int64_t n, vSorted)
-                LogPrintf("%+d  ", n);
-            LogPrintf("|  ");
-        }
-        LogPrintf("nTimeOffset = %+d  (%+d minutes)\n", nTimeOffset, nTimeOffset/60);
-    }
 }
 
 uint32_t insecure_rand_Rz = 11;

--- a/src/util.h
+++ b/src/util.h
@@ -13,6 +13,7 @@
 
 #include "compat.h"
 #include "serialize.h"
+#include "sync.h"
 #include "tinyformat.h"
 
 #include <cstdio>
@@ -33,7 +34,6 @@
 #include <boost/filesystem/path.hpp>
 #include <boost/thread.hpp>
 
-class CNetAddr;
 class uint256;
 
 static const int64_t COIN = 100000000;
@@ -104,6 +104,10 @@ extern std::string strMiscWarning;
 extern bool fNoListen;
 extern bool fLogTimestamps;
 extern volatile bool fReopenDebugLog;
+
+// The code needed access to these was moved to netbase.cpp temporarily at least
+extern CCriticalSection cs_nTimeOffset;
+extern int64_t nTimeOffset;
 
 void RandAddSeed();
 void RandAddSeedPerfmon();
@@ -200,7 +204,6 @@ int64_t GetTime();
 void SetMockTime(int64_t nMockTimeIn);
 int64_t GetAdjustedTime();
 int64_t GetTimeOffset();
-void AddTimeData(const CNetAddr& ip, int64_t nTime);
 void runCommand(std::string strCommand);
 
 

--- a/src/version.h
+++ b/src/version.h
@@ -20,7 +20,7 @@ static const int INIT_PROTO_VERSION = 209;
 // ToDo: For now we can set this to an old value (random), and try to sync
 // with the network, once a hard fork is certain and we are ready to upgrade
 // we need to set this to a value we can support.
-static const int MIN_PEER_PROTO_VERSION = 70007;
+static const int MIN_PEER_PROTO_VERSION = 70006;
 
 // nTime field added to CAddress, starting with this version;
 // if possible, avoid requesting addresses nodes older than this

--- a/src/version.h
+++ b/src/version.h
@@ -11,7 +11,7 @@
 // network protocol versioning
 //
 
-static const int PROTOCOL_VERSION = 70008;
+static const int PROTOCOL_VERSION = 70009;
 
 // intial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;


### PR DESCRIPTION
Primarily these changes introduce the concept of having a built-in I2P b32.i2p destination lookup system.  By adding address manager functionality each node can quickly locate other I2P peers without the need of using long complicated base64 keys.  The PeerTable display uses these now as do RPC commands and queries. A new query has been added called 'destination', which allows the user to view the state of all or selected I2P details found there and which are currently flowing through the AddrMan as part of normal operations.  Peers aggressively share possible connection details with one another, past designs used 1000 entries, ~546KB of payload, unless the build only supports IP addresses, in which case that is now supported as a possibility during version handshake.  Most builds do not have that limitation, and share full size objects, in this way I2P destinations are also shared with peers.  Each entry much larger that an IP (16 byte) address.  So this has been reduced by 1/4, 250 entries when requests are made,  and should help speed up Anoncoin network operations as new builds become commonly in use.

Additional security measures have been taken to protect privacy, one concept has an additional purpose, the introduction of a GarlicCat value has been added to these builds, destroying any IP address which might otherwise have been found while sharing I2P destinations.  The IP field, much like the OnionCat concept already in place for Tor, is now being used to indicate an I2P destination is provided by this destination, not an IP address.  Likewise if its a valid IP address the I2P portion of each object is zeroed out and not allowed to be used for any other purpose.  As these builds expand across the Anoncoin network a healing process can begin within its P2P address space. Enforced as much as possible is the sharing of only validated, corrected and secure information. 

Also introduced is the 1st working builds of Protocol 70009, Clearnet peers are now fully supported, and backwards compatible for 70006 and 70007, regardless of wither or not they have been build for clearnet or I2P.  Protocol 70008 was depreciated as it only worked for I2P.  Nodes can now simultaneously have either or both Clearnet and I2P peers connected, and proxy/Tor support is being maintained.
