### PR TITLE
Updated obsolete package instructions

### DIFF
--- a/doc/readme-qt.rst
+++ b/doc/readme-qt.rst
@@ -32,7 +32,14 @@ For Qt 5 you need the following, otherwise you get an error with lrelease when r
 
 ::
 
+    apt-get install qt5-qmake libqt5gui5 libqt5core5 libqt5dbus5 qttools5-dev-tools
+
+for Ubuntu >= 14.04:
+
+::
+
     apt-get install qt5-qmake libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev-tools
+
 
 then execute the following:
 

--- a/doc/readme-qt.rst
+++ b/doc/readme-qt.rst
@@ -32,7 +32,7 @@ For Qt 5 you need the following, otherwise you get an error with lrelease when r
 
 ::
 
-    apt-get install qt5-qmake libqt5gui5 libqt5core5 libqt5dbus5 qttools5-dev-tools
+    apt-get install qt5-qmake libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev-tools
 
 then execute the following:
 


### PR DESCRIPTION
Full message on Ubuntu:

Package libqtcore5 is not available, but is referred to by another package. This may mean that the package is missing, has been obsoleted, or is only available from another source
However the following packages replace it:
    libqt5core5a:i386  libqtcore5a
